### PR TITLE
exclude artifact directory in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ build/
 graphlearn/proto/service.pb*
 graphlearn/proto/service.grpc*
 graphlearn.egg-info/
+graphlearn/python/lib
+dist/


### PR DESCRIPTION
I noticed that these two path were generated during compiling phase.

I think it's better to list them in the `.gitignore` file, isn't it?