### PR TITLE
hg: Softmax on coefficients for each segment_id

### DIFF
--- a/graphlearn/python/model/tf/layers/gat_conv.py
+++ b/graphlearn/python/model/tf/layers/gat_conv.py
@@ -78,8 +78,10 @@ class GATConv(BaseConv):
       neigh_vecs = tf.reduce_sum(neigh_vecs, axis=1)
     else:  # full neighbor GAT
       self_vecs_extend = tf.gather(self_vecs, segment_ids)
-      coefficients = tf.nn.softmax(tf.nn.leaky_relu(self._attn_fc(
+      coefficients = tf.math.exp(tf.nn.leaky_relu(self._attn_fc(
           tf.concat([self_vecs_extend, neigh_vecs], axis=-1))))
+      seg_sum = tf.gather(tf.segment_sum(coefficients, segment_ids), segment_ids)
+      coefficients = coefficients / seg_sum
       coefficients = tf.nn.dropout(coefficients, 1 - self._attn_drop)
       neigh_vecs = tf.multiply(coefficients, neigh_vecs)
       neigh_vecs = tf.segment_sum(neigh_vecs, segment_ids)


### PR DESCRIPTION
Paper: https://arxiv.org/pdf/1710.10903.pdf
Regarding Equation (3), Softmax is applied on each node and it's neighbors, not all the nodes in the batch and their neighbors. I modify the code to calculate Softmax only on all the neighbors within each segment_id, which should be the correct implementation according to the paper.