### PR TITLE
Support both distribute ServiceMode and TaskMode, fix iteration bug.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -320,6 +320,7 @@ test:so gtest
 	$(CXX) $(CXXFLAGS) graphlearn/service/test/tensor_unittest.cpp -o built/bin/tensor_unittest $(TEST_FLAG)
 	$(CXX) $(CXXFLAGS) graphlearn/service/test/client_test.cpp -o built/bin/client_test $(TEST_FLAG)
 	$(CXX) $(CXXFLAGS) graphlearn/service/test/server_test.cpp -o built/bin/server_test $(TEST_FLAG)
+	$(CXX) $(CXXFLAGS) graphlearn/service/test/dist_in_memory_test.cpp -o built/bin/dist_in_memory_test $(TEST_FLAG)
 	$(CXX) $(CXXFLAGS) graphlearn/service/request/test/graph_request_unittest.cpp -o built/bin/graph_request_unittest $(TEST_FLAG)
 	$(CXX) $(CXXFLAGS) graphlearn/service/request/test/aggregating_request_unittest.cpp -o built/bin/aggregating_request_unittest $(TEST_FLAG)
 	$(CXX) $(CXXFLAGS) graphlearn/service/dist/test/naming_engine_unittest.cpp -o built/bin/naming_engine_unittest $(TEST_FLAG)

--- a/examples/basic/distribute/run_test.sh
+++ b/examples/basic/distribute/run_test.sh
@@ -23,4 +23,20 @@ python $HERE/test.py \
 sleep 1
 python $HERE/test.py \
   --cluster="{\"client_count\": 2, \"tracker\": \"$HERE/tracker\", \"server_count\": 2}" \
-  --job_name="client" --task_index=1 &
+  --job_name="client" --task_index=1
+
+# test iterate with server cout < client cout.
+sleep 5
+rm -rf $HERE/tracker
+mkdir -p $HERE/tracker
+python $HERE/test_iterate.py \
+  --cluster="{\"client_count\": 2, \"tracker\": \"$HERE/tracker\", \"server_count\": 1}" \
+  --job_name="server" --task_index=0 &
+sleep 1
+python $HERE/test_iterate.py \
+  --cluster="{\"client_count\": 2, \"tracker\": \"$HERE/tracker\", \"server_count\": 1}" \
+  --job_name="client" --task_index=0 &
+sleep 1
+python $HERE/test_iterate.py \
+  --cluster="{\"client_count\": 2, \"tracker\": \"$HERE/tracker\", \"server_count\": 1}" \
+  --job_name="client" --task_index=1

--- a/examples/basic/distribute/run_test_in_memory.sh
+++ b/examples/basic/distribute/run_test_in_memory.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+HERE=$(cd "$(dirname "$0")";pwd)
+
+rm -rf $HERE/tracker
+mkdir -p $HERE/tracker
+
+if [ ! -d "$HERE/data" ]; then
+  mkdir -p $HERE/data
+  python $HERE/gen_test_data.py
+fi
+
+python $HERE/test_in_memory.py \
+  --task_index=0 --task_count=2 --tracker="$HERE/tracker" &
+sleep 1
+python $HERE/test_in_memory.py \
+  --task_index=1 --task_count=2 --tracker="$HERE/tracker"

--- a/examples/basic/distribute/test.py
+++ b/examples/basic/distribute/test.py
@@ -8,6 +8,7 @@ import sys
 
 import graphlearn as gl
 import numpy as np
+import time
 
 
 def main(argv):
@@ -41,12 +42,14 @@ def main(argv):
 
   if job_name == "server":
     print("Server {} started.".format(task_index))
+    g.wait_for_close()
 
   if job_name == "client":
     print("Client {} started.".format(task_index))
 
     print("Get Edges...")
-    edges = g.E("buy").batch(2).emit()
+    edges = g.E("buy").batch(2).shuffle().emit()
+    print(edges.src_ids)
     print(edges.dst_ids)
     print(edges.weights)
     print("Get Edges Done...")
@@ -57,7 +60,7 @@ def main(argv):
     print(nodes.ids)
     print(nodes.weights)
     print("Get item Nodes...")
-    nodes = g.V("item").batch(4).emit()
+    nodes = g.V("item").batch(4).shuffle().emit()
     print(nodes.ids)
     print(nodes.int_attrs)
     print(nodes.float_attrs)
@@ -93,6 +96,8 @@ def main(argv):
     s = g.negative_sampler("user", expand_factor=3, strategy="node_weight")
     print(s.get(np.array([0, 1, 2])).ids)
     print("NodeWeight Negative Sample Done...")
+    g.close()
+    print("Client {} stopped.".format(task_index))
 
 
 if __name__ == "__main__":

--- a/examples/basic/distribute/test_in_memory.py
+++ b/examples/basic/distribute/test_in_memory.py
@@ -1,0 +1,96 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import getopt
+import os
+import sys
+
+import graphlearn as gl
+import numpy as np
+import time
+
+
+def main(argv):
+  cur_path = sys.path[0]
+
+  task_index = 0
+  task_count = 1
+  tarcker = ""
+
+  opts, args = getopt.getopt(argv, 'c:j:t:', ['task_index=', 'task_count=', 'tracker='])
+  for opt, arg in opts:
+    if opt in ('-c', '--task_index'):
+      task_index = int(arg)
+    elif opt in ('-j', '--task_count'):
+      task_count = int(arg)
+    elif opt in ('-t', '--tracker'):
+      tracker = arg
+    else:
+      pass
+
+  g = gl.Graph()
+
+  g.node(os.path.join(cur_path, "data/user"),
+         node_type="user", decoder=gl.Decoder(weighted=True)) \
+    .node(os.path.join(cur_path, "data/item"),
+          node_type="item", decoder=gl.Decoder(attr_types=['string', 'int', 'float', 'float', 'string'])) \
+    .edge(os.path.join(cur_path, "data/u-i"),
+          edge_type=("user", "item", "buy"), decoder=gl.Decoder(weighted=True))
+
+  g.init(task_index=task_index, task_count=task_count, tracker=tracker)
+
+  print("Get Edges...")
+  edges = g.E("buy").batch(2).shuffle().emit()
+  print(edges.src_ids)
+  print(edges.dst_ids)
+  print(edges.weights)
+  print("Get Edges Done...")
+
+  print("Get Nodes...")
+  print("Get user Nodes...")
+  nodes = g.V("user", np.array([0, 1, 2, 3, 4])).emit()
+  print(nodes.ids)
+  print(nodes.weights)
+  print("Get item Nodes...")
+  nodes = g.V("item").batch(4).shuffle().emit()
+  print(nodes.ids)
+  print(nodes.int_attrs)
+  print(nodes.float_attrs)
+  print(nodes.string_attrs)
+  print("Query item Nodes...")
+  nodes = g.V("item", np.array([101, 102, 103])).emit()
+  print(nodes.ids)
+  print(nodes.int_attrs)
+  print("Get Nodes Done...")
+
+  print("Random sample...")
+  s = g.neighbor_sampler("buy", expand_factor=2, strategy="random")
+  nodes = s.get(np.array([0, 1, 2])).layer_nodes(1)
+  print(nodes.ids)
+  print(nodes.float_attrs)
+  print(nodes.embedding_agg(func="mean"))
+  print("Random Sample Done...")
+
+  print("Full sample...")
+  s = g.neighbor_sampler("buy", expand_factor=2, strategy="full")
+  nodes = s.get(np.array([0, 1, 2])).layer_nodes(1)
+  print(nodes.ids)
+  print(nodes.offsets)
+  print(nodes.embedding_agg())
+  print("Full Sample Done...")
+
+  print("InDegree neg sample...")
+  s = g.negative_sampler("buy", expand_factor=3, strategy="in_degree")
+  print(s.get(np.array([0, 1, 2])).ids)
+  print("InDegree Negative Sample Done...")
+
+  print("NodeWeight neg sample...")
+  s = g.negative_sampler("user", expand_factor=3, strategy="node_weight")
+  print(s.get(np.array([0, 1, 2])).ids)
+  print("NodeWeight Negative Sample Done...")
+  g.close()
+
+
+if __name__ == "__main__":
+  main(sys.argv[1:])

--- a/examples/basic/distribute/test_iterate.py
+++ b/examples/basic/distribute/test_iterate.py
@@ -1,0 +1,69 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import getopt
+import os
+import sys
+
+import graphlearn as gl
+import numpy as np
+import time
+
+
+def main(argv):
+  cur_path = sys.path[0]
+
+  cluster = ""
+  job_name = ""
+  task_index = 0
+
+  opts, args = getopt.getopt(argv, 'c:j:t:', ['cluster=', 'job_name=', 'task_index='])
+  for opt, arg in opts:
+    if opt in ('-c', '--cluster'):
+      cluster = arg
+    elif opt in ('-j', '--job_name'):
+      job_name = arg
+    elif opt in ('-t', '--task_index'):
+      task_index = int(arg)
+    else:
+      pass
+
+  g = gl.Graph()
+
+  g.node(os.path.join(cur_path, "data/user"),
+         node_type="user", decoder=gl.Decoder(weighted=True)) \
+    .node(os.path.join(cur_path, "data/item"),
+          node_type="item", decoder=gl.Decoder(attr_types=['string', 'int', 'float', 'float', 'string'])) \
+    .edge(os.path.join(cur_path, "data/u-i"),
+          edge_type=("user", "item", "buy"), decoder=gl.Decoder(weighted=True))
+
+  g.init(cluster=cluster, job_name=job_name, task_index=task_index)
+
+  if job_name == "server":
+    print("Server {} started.".format(task_index))
+    g.wait_for_close()
+
+  if job_name == "client":
+    print("Client {} started.".format(task_index))
+    q = g.V("user").batch(10).values()
+    for i in range(3):
+      while True:
+        try:
+          print(g.run(q).ids)
+        except gl.OutOfRangeError:
+          print("Out of range......")
+          break
+
+    q = g.E("buy").batch(10).values()
+    for i in range(3):
+      while True:
+        try:
+          print(g.run(q).dst_ids)
+        except gl.OutOfRangeError:
+          print("Out of range......")
+          break
+    g.close()
+
+if __name__ == "__main__":
+  main(sys.argv[1:])

--- a/graphlearn/common/base/macros.h
+++ b/graphlearn/common/base/macros.h
@@ -25,11 +25,21 @@ limitations under the License.
 
 #define BREAK_IF_NOT_OK(s)                  \
   if (!s.ok()) {                            \
+    break;                                  \
+  }
+
+#define LOG_BREAK_IF_NOT_OK(s)              \
+  if (!s.ok()) {                            \
     LOG(ERROR) << s.ToString();             \
     break;                                  \
   }
 
 #define RETURN_IF_NOT_OK(s)                 \
+  if (!s.ok()) {                            \
+    return s;                               \
+  }
+
+#define LOG_RETURN_IF_NOT_OK(s)             \
   if (!s.ok()) {                            \
     LOG(ERROR) << s.ToString();             \
     return s;                               \

--- a/graphlearn/common/base/progress.h
+++ b/graphlearn/common/base/progress.h
@@ -24,13 +24,13 @@ limitations under the License.
 #include "graphlearn/common/threading/sync/lock.h"
 
 #define PROGRESSING(key)                   \
-  static ::graphlearn::profiling::Progress key##_progress(#key);
+  static ::graphlearn::profiling::Progress key##_progress(#key)
 
 #define PROGRESSINGG(key, g)               \
-  static ::graphlearn::profiling::Progress key##_progress(#key, g);
+  static ::graphlearn::profiling::Progress key##_progress(#key, g)
 
 #define UPDATE_PROGRESSING(key, counter)   \
-  key##_progress.Add(counter);
+  key##_progress.Add(counter)
 
 namespace graphlearn {
 namespace profiling {

--- a/graphlearn/common/io/value.h
+++ b/graphlearn/common/io/value.h
@@ -115,7 +115,7 @@ struct Schema {
   }
 
   static DataType Translate(DataType t) {
-    static DataType TransBitmap[] = {kInt32, kInt32, kDouble, kDouble, kString};
+    static DataType TransBitmap[] = {kInt32, kInt32, kFloat, kFloat, kString};
     return t < kUnknown ? TransBitmap[t] : kUnknown;
   }
 
@@ -135,8 +135,8 @@ struct Schema {
       DataType t = Translate(types[i]);
       if (t == kInt32) {
         ss << "int,";
-      } else if (t == kDouble) {
-        ss << "double,";
+      } else if (t == kFloat) {
+        ss << "float,";
       } else if (t == kString) {
         ss << "string,";
       } else {

--- a/graphlearn/core/io/parser.cc
+++ b/graphlearn/core/io/parser.cc
@@ -45,6 +45,9 @@ Status ParseAttribute(
     ::graphlearn::strings::Split(input, delimiter);
 
   if (attrs.size() != types.size()) {
+    LOG(ERROR) << "The count of attributes does not match your decoder"
+               << ", expect:" << types.size()
+               << ", actual:" << attrs.size();
     return error::InvalidArgument("Unexpected attribute count");
   }
 

--- a/graphlearn/core/io/slice_reader.h
+++ b/graphlearn/core/io/slice_reader.h
@@ -50,17 +50,21 @@ public:
 
     FileSystem* fs = NULL;
     Status s = env_->GetFileSystem(current_->path, &fs);
-    RETURN_IF_NOT_OK(s)
+    LOG_RETURN_IF_NOT_OK(s)
 
     uint64_t file_size = 0;
     s = fs->GetRecordCount(current_->path, &file_size);
-    RETURN_IF_NOT_OK(s)
+    LOG_RETURN_IF_NOT_OK(s)
 
     DataSlicer slicer(env_->GetServerId() * thread_num_ + thread_id_,
                       env_->GetServerCount() * thread_num_,
                       file_size);
     offset_ = slicer.LocalStart();
     end_ = offset_ + slicer.LocalSize();
+    LOG(INFO) << "thread id:" << thread_id_
+              << ", thread num:" << thread_num_
+              << ", offset:" << offset_
+              << ", end:" << end_;
 
     s = fs->NewStructuredAccessFile(current_->path, offset_, &reader_);
     RETURN_IF_NOT_OK(s)

--- a/graphlearn/core/operator/graph/test/graph_op_unittest.cpp
+++ b/graphlearn/core/operator/graph/test/graph_op_unittest.cpp
@@ -272,6 +272,8 @@ TEST_F(GraphOpTest, EdgeGetter) {
       delete res;
       delete req;
     }
+
+
   }
 }
 

--- a/graphlearn/core/operator/sampler/edge_weight_sampler.cc
+++ b/graphlearn/core/operator/sampler/edge_weight_sampler.cc
@@ -34,7 +34,6 @@ public:
 
     res->SetBatchSize(batch_size);
     res->SetNeighborCount(count);
-    res->InitDegrees(batch_size);
     res->InitNeighborIds(batch_size * count);
     res->InitEdgeIds(batch_size * count);
 

--- a/graphlearn/core/operator/sampler/in_degree_negative_sampler.cc
+++ b/graphlearn/core/operator/sampler/in_degree_negative_sampler.cc
@@ -36,7 +36,6 @@ public:
 
     res->SetBatchSize(batch_size);
     res->SetNeighborCount(count);
-    res->InitDegrees(batch_size);
     res->InitEdgeIds(batch_size * count);
     res->InitNeighborIds(batch_size * count);
 

--- a/graphlearn/core/operator/sampler/in_degree_sampler.cc
+++ b/graphlearn/core/operator/sampler/in_degree_sampler.cc
@@ -35,7 +35,6 @@ public:
     res->SetBatchSize(batch_size);
     res->SetNeighborCount(count);
     res->InitNeighborIds(batch_size * count);
-    res->InitDegrees(batch_size);
     res->InitEdgeIds(batch_size * count);
 
     const std::string& edge_type = req->Type();

--- a/graphlearn/core/operator/sampler/node_weight_negative_sampler.cc
+++ b/graphlearn/core/operator/sampler/node_weight_negative_sampler.cc
@@ -36,7 +36,6 @@ public:
 
     res->SetBatchSize(batch_size);
     res->SetNeighborCount(count);
-    res->InitDegrees(batch_size);
     res->InitEdgeIds(batch_size * count);
     res->InitNeighborIds(batch_size * count);
 

--- a/graphlearn/core/operator/sampler/random_negative_sampler.cc
+++ b/graphlearn/core/operator/sampler/random_negative_sampler.cc
@@ -32,7 +32,6 @@ public:
 
     res->SetBatchSize(batch_size);
     res->SetNeighborCount(count);
-    res->InitDegrees(batch_size);
     res->InitEdgeIds(batch_size * count);
     res->InitNeighborIds(batch_size * count);
 

--- a/graphlearn/core/operator/sampler/random_sampler.cc
+++ b/graphlearn/core/operator/sampler/random_sampler.cc
@@ -32,7 +32,6 @@ public:
 
     res->SetBatchSize(batch_size);
     res->SetNeighborCount(count);
-    res->InitDegrees(batch_size);
     res->InitNeighborIds(batch_size * count);
     res->InitEdgeIds(batch_size * count);
 

--- a/graphlearn/core/operator/sampler/random_without_replacement_sampler.cc
+++ b/graphlearn/core/operator/sampler/random_without_replacement_sampler.cc
@@ -35,7 +35,6 @@ public:
 
     res->SetBatchSize(batch_size);
     res->SetNeighborCount(count);
-    res->InitDegrees(batch_size);
     res->InitNeighborIds(batch_size * count);
     res->InitEdgeIds(batch_size * count);
 

--- a/graphlearn/core/operator/sampler/topk_sampler.cc
+++ b/graphlearn/core/operator/sampler/topk_sampler.cc
@@ -32,7 +32,6 @@ public:
 
     res->SetBatchSize(batch_size);
     res->SetNeighborCount(count);
-    res->InitDegrees(batch_size);
     res->InitNeighborIds(batch_size * count);
     res->InitEdgeIds(batch_size * count);
 

--- a/graphlearn/include/aggregating_request.h
+++ b/graphlearn/include/aggregating_request.h
@@ -30,7 +30,6 @@ public:
 
   OpRequest* Clone() const override;
   void SerializeTo(void* request) override;
-  bool ParseFrom(const void* request) override;
 
   void Set(const int64_t* node_ids,
            const int32_t* segment_ids,
@@ -43,6 +42,9 @@ public:
   int32_t NumIds() const { return node_ids_->Size(); }
   bool SegmentEnd(int32_t segment_id) const;
   int32_t NumSegments() const { return num_segments_; }
+
+protected:
+  void SetMembers() override;
 
 private:
   int32_t cursor_;
@@ -60,6 +62,8 @@ public:
     return new AggregatingResponse;
   }
 
+  void Swap(OpResponse& right) override;
+
   void SetName(const std::string& name);
   void SetEmbeddingDim(int32_t dim);
   void SetNumSegments(int32_t dim);
@@ -74,8 +78,10 @@ public:
   void AppendSegment(int32_t size);
   const int32_t* Segments() const;
 
-  bool ParseFrom(const void* response) override;
   void Stitch(ShardsPtr<OpResponse> shards) override;
+
+protected:
+  void SetMembers() override;
 
 private:
   std::string name_;

--- a/graphlearn/include/graph_request.h
+++ b/graphlearn/include/graph_request.h
@@ -35,12 +35,13 @@ public:
   UpdateRequest(const io::SideInfo* info, int32_t batch_size);
   virtual ~UpdateRequest();
 
-  bool ParseFrom(const void* request) override;
-
   void Append(const io::AttributeValue* value);
   const io::SideInfo* GetSideInfo() const;
   int32_t Size() const;
   void Next(io::AttributeValue* value);
+
+protected:
+  void SetMembers() override;
 
 protected:
   io::SideInfo* info_;
@@ -62,11 +63,13 @@ public:
 
   OpRequest* Clone() const override;
   void SerializeTo(void* request) override;
-  bool ParseFrom(const void* request) override;
 
   int32_t Size() const;
   void Append(const io::EdgeValue* value);
   bool Next(io::EdgeValue* value);
+
+protected:
+  void SetMembers() override;
 
 private:
   Tensor* src_ids_;
@@ -92,11 +95,13 @@ public:
 
   OpRequest* Clone() const override;
   void SerializeTo(void* request) override;
-  bool ParseFrom(const void* request) override;
 
   int32_t Size() const;
   void Append(const io::NodeValue* value);
   bool Next(io::NodeValue* value);
+
+protected:
+  void SetMembers() override;
 
 private:
   Tensor* ids_;
@@ -118,12 +123,14 @@ public:
   GetEdgesRequest();
   GetEdgesRequest(const std::string& edge_type,
                   const std::string& strategy,
-                  int32_t batch_size);
+                  int32_t batch_size,
+                  int32_t epoch = 0);
   virtual ~GetEdgesRequest() = default;
 
   const std::string& EdgeType() const;
   const std::string& Strategy() const;
   int32_t BatchSize() const;
+  int32_t Epoch() const;
 };
 
 class GetEdgesResponse : public OpResponse {
@@ -135,7 +142,7 @@ public:
     return new GetEdgesResponse;
   }
 
-  bool ParseFrom(const void* response) override;
+  void Swap(OpResponse& right) override;
 
   void Init(int32_t batch_size);
   void Append(int64_t src_id, int64_t dst_id, int64_t edge_id);
@@ -143,6 +150,9 @@ public:
   const int64_t* SrcIds() const;
   const int64_t* DstIds() const;
   const int64_t* EdgeIds() const;
+
+protected:
+  void SetMembers() override;
 
 private:
   Tensor* src_ids_;
@@ -156,13 +166,15 @@ public:
   GetNodesRequest(const std::string& type,
                   const std::string& strategy,
                   NodeFrom node_from,
-                  int32_t batch_size);
+                  int32_t batch_size,
+                  int32_t epoch = 0);
   virtual ~GetNodesRequest() = default;
 
   const std::string& Type() const;
   const std::string& Strategy() const;
   NodeFrom GetNodeFrom() const;
   int32_t BatchSize() const;
+  int32_t Epoch() const;
 };
 
 class GetNodesResponse : public OpResponse {
@@ -174,12 +186,15 @@ public:
     return new GetNodesResponse;
   }
 
-  bool ParseFrom(const void* response) override;
+  void Swap(OpResponse& right) override;
 
   void Init(int32_t batch_size);
   void Append(int64_t node_id);
   int32_t Size() const { return batch_size_; }
   const int64_t* NodeIds() const;
+
+protected:
+  void SetMembers() override;
 
 private:
   Tensor* node_ids_;
@@ -193,8 +208,6 @@ public:
 
   OpRequest* Clone() const override;
 
-  bool ParseFrom(const void* request) override;
-
   void Set(const int64_t* edge_ids,
            const int64_t* src_ids,
            int32_t batch_size);
@@ -202,6 +215,9 @@ public:
   const std::string& EdgeType() const;
   int32_t Size() const;
   bool Next(int64_t* edge_id, int64_t* src_id);
+
+protected:
+  void SetMembers() override;
 
 private:
   int32_t cursor_;
@@ -217,13 +233,14 @@ public:
 
   OpRequest* Clone() const override;
 
-  bool ParseFrom(const void* request) override;
-
   void Set(const int64_t* node_ids, int32_t batch_size);
 
   const std::string& NodeType() const;
   int32_t Size() const;
   bool Next(int64_t* node_id);
+
+protected:
+  void SetMembers() override;
 
 private:
   int32_t cursor_;
@@ -235,7 +252,7 @@ public:
   LookupResponse();
   virtual ~LookupResponse();
 
-  bool ParseFrom(const void* response) override;
+  void Swap(OpResponse& right) override;
 
   void SetSideInfo(const io::SideInfo* info, int32_t batch_size);
   void AppendWeight(float weight);
@@ -252,6 +269,9 @@ public:
   const int64_t* IntAttrs() const;
   const float* FloatAttrs() const;
   const std::string* StringAttrs() const;
+
+protected:
+  void SetMembers() override;
 
 protected:
   io::SideInfo* info_;

--- a/graphlearn/include/op_request.h
+++ b/graphlearn/include/op_request.h
@@ -49,6 +49,15 @@ public:
 
   ShardsPtr<OpRequest> Partition() const override;
 
+protected:
+  // All parameters and values come from params_ and tensors_.
+  // To simplify usage, we may need some private members pointing to
+  // the elements of params_ and tensors_, such as
+  // ``` src_ids_ = &(params_[kNeighborCount]); ```
+  // ``` SetMembers() ``` is designed for this. Requests inheriting from
+  // ``` OpRequest ``` should implement their own ``` SetMembers() ```.
+  virtual void SetMembers() {}
+
 public:
   std::unordered_map<std::string, Tensor> params_;
   std::unordered_map<std::string, Tensor> tensors_;
@@ -70,10 +79,19 @@ public:
   bool ParseFrom(const void* response) override;
 
   void Stitch(ShardsPtr<OpResponse> shards) override;
-  void Swap(OpResponse& right);
+  virtual void Swap(OpResponse& right);
 
   void SetSparseFlag() { is_sparse_ = true; }
   bool IsSparse() const { return is_sparse_; }
+
+protected:
+  // All parameters and values come from params_ and tensors_.
+  // To simplify usage, we may need some private members pointing to
+  // the elements of params_ and tensors_, such as
+  // ``` src_ids_ = &(params_[kNeighborCount]); ```
+  // ``` SetMembers() ``` is designed for this. Responses inheriting from
+  // ``` OpResponse ``` should implement their own ``` SetMembers() ```.
+  virtual void SetMembers() {}
 
 public:
   int32_t batch_size_;

--- a/graphlearn/include/sampling_request.h
+++ b/graphlearn/include/sampling_request.h
@@ -30,8 +30,6 @@ public:
   ~SamplingRequest() = default;
 
   OpRequest* Clone() const override;
-  void SerializeTo(void* request) override;
-  bool ParseFrom(const void* request) override;
 
   void Set(const int64_t* src_ids, int32_t batch_size);
 
@@ -40,6 +38,9 @@ public:
   int32_t BatchSize() const;
   int32_t NeighborCount() const { return neighbor_count_; }
   const int64_t* GetSrcIds() const;
+
+protected:
+  void SetMembers() override;
 
 private:
   int32_t neighbor_count_;
@@ -55,8 +56,8 @@ public:
     return new SamplingResponse;
   }
 
+  void Swap(OpResponse& right) override;
   void SerializeTo(void* response) override;
-  bool ParseFrom(const void* response) override;
   void Stitch(ShardsPtr<OpResponse> shards) override;
 
   void InitNeighborIds(int32_t count);
@@ -79,6 +80,9 @@ public:
   const int64_t* GetNeighborIds() const;
   const int64_t* GetEdgeIds() const;
   const int32_t* GetDegrees() const;
+
+protected:
+  void SetMembers() override;
 
 private:
   int32_t neighbor_count_;

--- a/graphlearn/platform/env.cc
+++ b/graphlearn/platform/env.cc
@@ -93,6 +93,7 @@ Status Env::GetFileSystem(const std::string& file_path,
   std::string scheme = io::GetScheme(file_path);
   FileSystem* file_system = fs_registry_->Lookup(scheme);
   if (!file_system) {
+    USER_LOG("Invalid file path: " + file_path);
     LOG(ERROR) << "File system not implemented: " << file_path;
     return Status(error::NOT_FOUND, "File system not implemented");
   }

--- a/graphlearn/platform/local/local_file_system.cc
+++ b/graphlearn/platform/local/local_file_system.cc
@@ -155,10 +155,9 @@ private:
         strings::FastStringTo32(items[i].c_str(), &v.n.i);
       } else if (schema_.types[i] == DataType::kInt64) {
         strings::FastStringTo64(items[i].c_str(), &v.n.l);
-      } else if (schema_.types[i] == DataType::kFloat) {
+      } else if (schema_.types[i] == DataType::kFloat ||
+          schema_.types[i] == DataType::kDouble) {
         strings::FastStringToFloat(items[i].c_str(), &v.n.f);
-      } else if (schema_.types[i] == DataType::kDouble) {
-        strings::FastStringToDouble(items[i].c_str(), &v.n.d);
       } else {
         v.s.Copy(items[i], true);
       }

--- a/graphlearn/python/py_export.cc
+++ b/graphlearn/python/py_export.cc
@@ -330,7 +330,8 @@ PYBIND11_MODULE(pywrap_graphlearn, m) {
         py::return_value_policy::reference,
         py::arg("edge_type"),
         py::arg("strategy"),
-        py::arg("batch_size"));
+        py::arg("batch_size"),
+        py::arg("epoch"));
 
   m.def("del_get_edge_req",
         [](GetEdgesRequest* req) {
@@ -442,7 +443,8 @@ PYBIND11_MODULE(pywrap_graphlearn, m) {
       py::arg("node_type"),
       py::arg("strategy"),
       py::arg("node_from"),
-      py::arg("batch_size"));
+      py::arg("batch_size"),
+      py::arg("epoch"));
 
   m.def("del_get_node_req",
         [](GetNodesRequest* req) {

--- a/graphlearn/python/py_wrapper.h
+++ b/graphlearn/python/py_wrapper.h
@@ -129,9 +129,10 @@ PyObject* get_nbr_res_degrees(::graphlearn::SamplingResponse* res) {
 }
 
 ::graphlearn::GetEdgesRequest* new_get_edge_req(const std::string& edge_type,
-                                              const std::string& strategy,
-                                              int32_t batch_size) {
-  return new ::graphlearn::GetEdgesRequest(edge_type, strategy, batch_size);
+                                                const std::string& strategy,
+                                                int32_t batch_size,
+                                                int32_t epoch) {
+  return new ::graphlearn::GetEdgesRequest(edge_type, strategy, batch_size, epoch);
 }
 
 void del_get_edge_req(::graphlearn::GetEdgesRequest* req) {
@@ -303,11 +304,12 @@ PyObject* get_edge_labels_res(::graphlearn::LookupEdgesResponse* res) {
 }
 
 ::graphlearn::GetNodesRequest* new_get_node_req(const std::string& type,
-                                               const std::string& strategy,
-                                               ::graphlearn::NodeFrom node_from,
-                                               int32_t batch_size) {
+                                                const std::string& strategy,
+                                                ::graphlearn::NodeFrom node_from,
+                                                int32_t batch_size,
+                                                int32_t epoch) {
   return new ::graphlearn::GetNodesRequest(
-    type, strategy, node_from, batch_size);
+    type, strategy, node_from, batch_size, epoch);
 }
 
 void del_get_node_req(::graphlearn::GetNodesRequest* req) {

--- a/graphlearn/python/sampler/negative_sampler.py
+++ b/graphlearn/python/sampler/negative_sampler.py
@@ -80,15 +80,16 @@ class NegativeSampler(object):
 
     req = self._make_req(ids)
     res = pywrap.new_nbr_res()
-    raise_exception_on_not_ok_status(self._client.sample_neighbor(req, res))
-
-    nbrs = pywrap.get_nbr_res_nbr_ids(res)
-    neg_nbrs = self._graph.get_nodes(self._dst_type,
-                                     nbrs,
-                                     shape=(ids.shape[0], self._expand_factor))
+    status = self._client.sample_neighbor(req, res)
+    if status.ok():
+      nbrs = pywrap.get_nbr_res_nbr_ids(res)
+      neg_nbrs = self._graph.get_nodes(self._dst_type,
+                                      nbrs,
+                                      shape=(ids.shape[0], self._expand_factor))
 
     pywrap.del_nbr_res(res)
     pywrap.del_nbr_req(req)
+    raise_exception_on_not_ok_status(status)
     return neg_nbrs
 
   def _make_req(self, ids):

--- a/graphlearn/python/sampler/neighbor_sampler.py
+++ b/graphlearn/python/sampler/neighbor_sampler.py
@@ -101,13 +101,14 @@ class NeighborSampler(object):
     for i in xrange(len(self._meta_path)):
       req = self._make_req(i, src_ids)
       res = pywrap.new_nbr_res()
-      raise_exception_on_not_ok_status(self._client.sample_neighbor(req, res))
-
-      nbr_ids = pywrap.get_nbr_res_nbr_ids(res)
-      edge_ids = pywrap.get_nbr_res_edge_ids(res)
+      status = self._client.sample_neighbor(req, res)
+      if status.ok():
+        nbr_ids = pywrap.get_nbr_res_nbr_ids(res)
+        edge_ids = pywrap.get_nbr_res_edge_ids(res)
 
       pywrap.del_nbr_res(res)
       pywrap.del_nbr_req(req)
+      raise_exception_on_not_ok_status(status)
 
       dst_type = self._dst_types[i]
       layer_nodes = self._graph.get_nodes(dst_type,
@@ -179,16 +180,17 @@ class FullNeighborSampler(NeighborSampler):
       # req, res & call method.
       req = self._make_req(i, src_ids)
       res = pywrap.new_nbr_res()
-      raise_exception_on_not_ok_status(self._client.sample_neighbor(req, res))
+      status = self._client.sample_neighbor(req, res)
+      if status.ok():
+        src_degrees = pywrap.get_nbr_res_degrees(res)
+        dense_shape = (current_batch_size, max(src_degrees))
 
-      src_degrees = pywrap.get_nbr_res_degrees(res)
-      dense_shape = (current_batch_size, max(src_degrees))
-
-      nbr_ids = pywrap.get_nbr_res_nbr_ids(res)
-      edge_ids = pywrap.get_nbr_res_edge_ids(res)
+        nbr_ids = pywrap.get_nbr_res_nbr_ids(res)
+        edge_ids = pywrap.get_nbr_res_edge_ids(res)
 
       pywrap.del_nbr_res(res)
       pywrap.del_nbr_req(req)
+      raise_exception_on_not_ok_status(status)
 
       dst_type = self._dst_types[i]
       layer_nodes = self._graph.get_nodes(dst_type,

--- a/graphlearn/python/sampler/tests/test_sampling.py
+++ b/graphlearn/python/sampler/tests/test_sampling.py
@@ -64,8 +64,7 @@ class SamplingTestCase(unittest.TestCase):
       .edge(source=edge3_path,
             edge_type=(self._node2_type, self._node2_type, self._edge3_type),
             decoder=self._edge3_decoder, directed=False)
-    self.__class__.g.init(server_id=0, server_count=1,
-                          tracker=utils.TRACKER_PATH)
+    self.__class__.g.init(tracker=utils.TRACKER_PATH)
 
   @classmethod
   def setUpClass(cls):
@@ -79,7 +78,7 @@ class SamplingTestCase(unittest.TestCase):
 
   @classmethod
   def tearDownClass(cls):
-    pass
+    cls.g.close()
 
   def setUp(self):
     """ prepare the data and the decoder.

--- a/graphlearn/python/state.py
+++ b/graphlearn/python/state.py
@@ -1,0 +1,31 @@
+# Copyright 2020 Alibaba Group Holding Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# =============================================================================
+import threading
+
+class State(object):
+  def __init__(self, value={}):
+    self._values = value
+    self._value_lock = threading.Lock()
+
+  def put(self, key, value):
+    with self._value_lock:
+      self._values[key] = value
+
+  def get(self, key):
+    return self._values.get(key, 0)
+
+  def inc(self, key, delta=1):
+    with self._value_lock:
+      self._values[key] = self._values.get(key, 0) + delta

--- a/graphlearn/python/tests/test_edge_attributed.py
+++ b/graphlearn/python/tests/test_edge_attributed.py
@@ -31,11 +31,13 @@ class AttributedEdgeTestCase(EdgeTestCase):
     decoder = gl.Decoder(attr_types=utils.ATTR_TYPES)
     g = gl.Graph() \
       .edge(source=file_path, edge_type=self.edge_tuple_, decoder=decoder)
-    g.init(server_id=0, server_count=1, tracker=utils.TRACKER_PATH)
+    g.init(tracker=utils.TRACKER_PATH)
 
     edges = g.get_edges(edge_type="first",
                         src_ids=self.src_ids_,
                         dst_ids=self.dst_ids_)
+
+    g.close()
 
 
 if __name__ == "__main__":

--- a/graphlearn/python/tests/test_edge_basic.py
+++ b/graphlearn/python/tests/test_edge_basic.py
@@ -31,13 +31,15 @@ class BasicEdgeTestCase(EdgeTestCase):
     decoder = gl.Decoder()
     g = gl.Graph() \
       .edge(source=file_path, edge_type=self.edge_tuple_, decoder=decoder)
-    g.init(server_id=0, server_count=1, tracker=utils.TRACKER_PATH)
+    g.init(tracker=utils.TRACKER_PATH)
 
     edges = g.E("first").batch(4).emit()
     utils.check_ids(edges.src_ids,
                     range(self.src_range_[0], self.src_range_[1]))
     utils.check_ids(edges.dst_ids,
                     range(self.dst_range_[0], self.dst_range_[1]))
+
+    g.close()
 
 
 if __name__ == "__main__":

--- a/graphlearn/python/tests/test_edge_iterate.py
+++ b/graphlearn/python/tests/test_edge_iterate.py
@@ -31,7 +31,7 @@ class EdgeIterateTestCase(EdgeTestCase):
     decoder = gl.Decoder(weighted=True)
     g = gl.Graph() \
       .edge(source=file_path, edge_type=self.edge_tuple_, decoder=decoder)
-    g.init(server_id=0, server_count=1, tracker=utils.TRACKER_PATH)
+    g.init(tracker=utils.TRACKER_PATH)
 
     batch_size = 4
     sampler = g.edge_sampler('first',
@@ -62,6 +62,8 @@ class EdgeIterateTestCase(EdgeTestCase):
       utils.check_edge_weights(edges)
       utils.check_subset(edges.src_ids, src_ids)
       utils.check_subset(edges.dst_ids, dst_ids)
+
+    g.close()
 
 
 if __name__ == "__main__":

--- a/graphlearn/python/tests/test_edge_iterate_gremlin.py
+++ b/graphlearn/python/tests/test_edge_iterate_gremlin.py
@@ -31,7 +31,7 @@ class EdgeIterateUsingGremlinTestCase(EdgeTestCase):
     decoder = gl.Decoder(weighted=True)
     g = gl.Graph() \
       .edge(source=file_path, edge_type=self.edge_tuple_, decoder=decoder)
-    g.init(server_id=0, server_count=1, tracker=utils.TRACKER_PATH)
+    g.init(tracker=utils.TRACKER_PATH)
 
     batch_size = 4
     query = g.E('first').batch(batch_size).values()
@@ -60,6 +60,8 @@ class EdgeIterateUsingGremlinTestCase(EdgeTestCase):
       utils.check_edge_weights(edges)
       utils.check_subset(edges.src_ids, src_ids)
       utils.check_subset(edges.dst_ids, dst_ids)
+
+    g.close()
 
 
 if __name__ == "__main__":

--- a/graphlearn/python/tests/test_edge_labeled.py
+++ b/graphlearn/python/tests/test_edge_labeled.py
@@ -31,7 +31,7 @@ class LabeledEdgeTestCase(EdgeTestCase):
     decoder = gl.Decoder(labeled=True)
     g = gl.Graph() \
       .edge(source=file_path, edge_type=self.edge_tuple_, decoder=decoder)
-    g.init(server_id=0, server_count=1, tracker=utils.TRACKER_PATH)
+    g.init(tracker=utils.TRACKER_PATH)
 
     edges = g.E("first").batch(self.batch_size_).emit()
     utils.check_ids(edges.src_ids,
@@ -39,6 +39,8 @@ class LabeledEdgeTestCase(EdgeTestCase):
     utils.check_ids(edges.dst_ids,
                     range(self.dst_range_[0], self.dst_range_[1]))
     utils.check_edge_labels(edges)
+
+    g.close()
 
 
 if __name__ == "__main__":

--- a/graphlearn/python/tests/test_edge_labeled_attributed.py
+++ b/graphlearn/python/tests/test_edge_labeled_attributed.py
@@ -31,7 +31,7 @@ class LabeledAttributedEdgeTestCase(EdgeTestCase):
     decoder = gl.Decoder(labeled=True, attr_types=utils.ATTR_TYPES)
     g = gl.Graph() \
       .edge(source=file_path, edge_type=self.edge_tuple_, decoder=decoder)
-    g.init(server_id=0, server_count=1, tracker=utils.TRACKER_PATH)
+    g.init(tracker=utils.TRACKER_PATH)
 
     edges = g.E("first").batch(self.batch_size_).emit()
     utils.check_ids(edges.src_ids,
@@ -40,6 +40,8 @@ class LabeledAttributedEdgeTestCase(EdgeTestCase):
                     range(self.dst_range_[0], self.dst_range_[1]))
     utils.check_edge_labels(edges)
     utils.check_edge_attrs(edges)
+
+    g.close()
 
 
 if __name__ == "__main__":

--- a/graphlearn/python/tests/test_edge_shuffle_gremlin.py
+++ b/graphlearn/python/tests/test_edge_shuffle_gremlin.py
@@ -31,7 +31,7 @@ class EdgeShuffleTestCase(EdgeTestCase):
     decoder = gl.Decoder(weighted=True)
     g = gl.Graph() \
       .edge(source=file_path, edge_type=self.edge_tuple_, decoder=decoder)
-    g.init(server_id=0, server_count=1, tracker=utils.TRACKER_PATH)
+    g.init(tracker=utils.TRACKER_PATH)
 
     batch_size = 4
     sampler = g.E('first').batch(batch_size).shuffle(traverse=True).values()
@@ -50,6 +50,8 @@ class EdgeShuffleTestCase(EdgeTestCase):
     dst_ids = range(self.dst_range_[0], self.dst_range_[1])
     utils.check_sorted_equal(res_src, src_ids)
     utils.check_sorted_equal(res_dst, dst_ids)
+
+    g.close()
 
 
 if __name__ == "__main__":

--- a/graphlearn/python/tests/test_edge_weighted.py
+++ b/graphlearn/python/tests/test_edge_weighted.py
@@ -31,7 +31,7 @@ class WeightedEdgeTestCase(EdgeTestCase):
     decoder = gl.Decoder(weighted=True)
     g = gl.Graph() \
       .edge(source=file_path, edge_type=self.edge_tuple_, decoder=decoder)
-    g.init(server_id=0, server_count=1, tracker=utils.TRACKER_PATH)
+    g.init(tracker=utils.TRACKER_PATH)
 
     edges = g.E("first").batch(self.batch_size_).emit()
     utils.check_ids(edges.src_ids,
@@ -39,6 +39,8 @@ class WeightedEdgeTestCase(EdgeTestCase):
     utils.check_ids(edges.dst_ids,
                     range(self.dst_range_[0], self.dst_range_[1]))
     utils.check_edge_weights(edges)
+
+    g.close()
 
 
 if __name__ == "__main__":

--- a/graphlearn/python/tests/test_edge_weighted_labeled.py
+++ b/graphlearn/python/tests/test_edge_weighted_labeled.py
@@ -31,7 +31,7 @@ class WeightedLabeledEdgeTestCase(EdgeTestCase):
     decoder = gl.Decoder(weighted=True, labeled=True)
     g = gl.Graph() \
       .edge(source=file_path, edge_type=self.edge_tuple_, decoder=decoder)
-    g.init(server_id=0, server_count=1, tracker=utils.TRACKER_PATH)
+    g.init(tracker=utils.TRACKER_PATH)
 
     edges = g.E("first").batch(self.batch_size_).emit()
     utils.check_ids(edges.src_ids,
@@ -40,6 +40,8 @@ class WeightedLabeledEdgeTestCase(EdgeTestCase):
                     range(self.dst_range_[0], self.dst_range_[1]))
     utils.check_edge_labels(edges)
     utils.check_edge_weights(edges)
+
+    g.close()
 
 
 if __name__ == "__main__":

--- a/graphlearn/python/tests/test_edge_weighted_labeled_attributed.py
+++ b/graphlearn/python/tests/test_edge_weighted_labeled_attributed.py
@@ -33,7 +33,7 @@ class WeightedLabeledAttributedEdgeTestCase(EdgeTestCase):
         weighted=True, labeled=True, attr_types=utils.ATTR_TYPES)
     g = gl.Graph() \
       .edge(source=file_path, edge_type=self.edge_tuple_, decoder=decoder)
-    g.init(server_id=0, server_count=1, tracker=utils.TRACKER_PATH)
+    g.init(tracker=utils.TRACKER_PATH)
 
     edges = g.E("first").batch(self.batch_size_).emit()
 
@@ -44,6 +44,8 @@ class WeightedLabeledAttributedEdgeTestCase(EdgeTestCase):
     utils.check_edge_labels(edges)
     utils.check_edge_attrs(edges)
     utils.check_edge_weights(edges)
+
+    g.close()
 
 
 if __name__ == "__main__":

--- a/graphlearn/python/tests/test_node_attributed.py
+++ b/graphlearn/python/tests/test_node_attributed.py
@@ -31,10 +31,12 @@ class AttributedNodeTestCase(NodeTestCase):
     decoder = gl.Decoder(attr_types=utils.ATTR_TYPES)
     g = gl.Graph() \
       .node(source=file_path, node_type=self.node_type_, decoder=decoder)
-    g.init(server_id=0, server_count=1, tracker=utils.TRACKER_PATH)
+    g.init(tracker=utils.TRACKER_PATH)
 
     nodes = g.get_nodes(node_type=self.node_type_, ids=self.ids_)
     self.check_attrs(nodes)
+
+    g.close()
 
 
 if __name__ == "__main__":

--- a/graphlearn/python/tests/test_node_form_graph_iterate.py
+++ b/graphlearn/python/tests/test_node_form_graph_iterate.py
@@ -31,7 +31,7 @@ class NodeFromGraphIterateTestCase(EdgeTestCase):
     decoder = gl.Decoder(attr_types=utils.ATTR_TYPES)
     g = gl.Graph() \
       .edge(source=file_path, edge_type=self.edge_tuple_, decoder=decoder)
-    g.init(server_id=0, server_count=1, tracker=utils.TRACKER_PATH)
+    g.init(tracker=utils.TRACKER_PATH)
 
     batch_size = 4
     sampler = g.node_sampler('first',
@@ -77,6 +77,8 @@ class NodeFromGraphIterateTestCase(EdgeTestCase):
     for i in range(max_iter):
       nodes = sampler.get()
       utils.check_subset(nodes.ids, ids)
+
+    g.close()
 
 
 if __name__ == "__main__":

--- a/graphlearn/python/tests/test_node_iterate.py
+++ b/graphlearn/python/tests/test_node_iterate.py
@@ -31,7 +31,7 @@ class NodeIterateTestCase(NodeTestCase):
     decoder = gl.Decoder(attr_types=utils.ATTR_TYPES)
     g = gl.Graph() \
       .node(source=file_path, node_type=self.node_type_, decoder=decoder)
-    g.init(server_id=0, server_count=1, tracker=utils.TRACKER_PATH)
+    g.init(tracker=utils.TRACKER_PATH)
 
     batch_size = 4
     sampler = g.node_sampler('user',
@@ -55,6 +55,8 @@ class NodeIterateTestCase(NodeTestCase):
       nodes = sampler.get()
       utils.check_node_attrs(nodes)
       utils.check_subset(nodes.ids, ids)
+
+    g.close()
 
 
 if __name__ == "__main__":

--- a/graphlearn/python/tests/test_node_iterate_gremlin.py
+++ b/graphlearn/python/tests/test_node_iterate_gremlin.py
@@ -31,7 +31,7 @@ class NodeIterateUsingGremlinTestCase(NodeTestCase):
     decoder = gl.Decoder(attr_types=utils.ATTR_TYPES)
     g = gl.Graph() \
       .node(source=file_path, node_type=self.node_type_, decoder=decoder)
-    g.init(server_id=0, server_count=1, tracker=utils.TRACKER_PATH)
+    g.init(tracker=utils.TRACKER_PATH)
 
     batch_size = 4
     query = g.V('user').batch(batch_size).values()
@@ -53,6 +53,8 @@ class NodeIterateUsingGremlinTestCase(NodeTestCase):
       nodes = g.run(query)
       utils.check_node_attrs(nodes)
       utils.check_subset(nodes.ids, ids)
+
+    g.close()
 
 
 if __name__ == "__main__":

--- a/graphlearn/python/tests/test_node_labeled.py
+++ b/graphlearn/python/tests/test_node_labeled.py
@@ -31,10 +31,12 @@ class LabeledNodeTestCase(NodeTestCase):
     decoder = gl.Decoder(labeled=True)
     g = gl.Graph() \
       .node(source=file_path, node_type=self.node_type_, decoder=decoder)
-    g.init(server_id=0, server_count=1, tracker=utils.TRACKER_PATH)
+    g.init(tracker=utils.TRACKER_PATH)
 
     nodes = g.get_nodes(node_type=self.node_type_, ids=self.ids_)
     self.check_labels(nodes)
+
+    g.close()
 
 
 if __name__ == "__main__":

--- a/graphlearn/python/tests/test_node_labeled_attributed.py
+++ b/graphlearn/python/tests/test_node_labeled_attributed.py
@@ -31,11 +31,13 @@ class LabeledAttributedNodeTestCase(NodeTestCase):
     decoder = gl.Decoder(labeled=True, attr_types=utils.ATTR_TYPES)
     g = gl.Graph() \
       .node(source=file_path, node_type=self.node_type_, decoder=decoder)
-    g.init(server_id=0, server_count=1, tracker=utils.TRACKER_PATH)
+    g.init(tracker=utils.TRACKER_PATH)
 
     nodes = g.get_nodes(node_type=self.node_type_, ids=self.ids_)
     self.check_labels(nodes)
     self.check_attrs(nodes)
+
+    g.close()
 
 
 if __name__ == "__main__":

--- a/graphlearn/python/tests/test_node_query.py
+++ b/graphlearn/python/tests/test_node_query.py
@@ -43,7 +43,7 @@ class NodeQueryTestCase(unittest.TestCase):
 
   @classmethod
   def tearDownClass(cls):
-    pass
+    cls.g.close()
 
   def setUp(self):
     self.node_type_ = 'user'

--- a/graphlearn/python/tests/test_node_query_attribute.py
+++ b/graphlearn/python/tests/test_node_query_attribute.py
@@ -34,8 +34,7 @@ class NodeQueryWeightTestCase(NodeQueryTestCase):
       .node(source=file_path,
             node_type=self.node_type_,
             decoder=decoder)
-    self.__class__.g.init(server_id=0, server_count=1,
-                          tracker=utils.TRACKER_PATH)
+    self.__class__.g.init(tracker=utils.TRACKER_PATH)
 
   def test_query_exist(self):
     nodes = self.g.get_nodes(node_type=self.node_type_,

--- a/graphlearn/python/tests/test_node_shuffle_gremlin.py
+++ b/graphlearn/python/tests/test_node_shuffle_gremlin.py
@@ -31,7 +31,7 @@ class NodeIterateTestCase(NodeTestCase):
     decoder = gl.Decoder(attr_types=utils.ATTR_TYPES)
     g = gl.Graph() \
       .node(source=file_path, node_type=self.node_type_, decoder=decoder)
-    g.init(server_id=0, server_count=1, tracker=utils.TRACKER_PATH)
+    g.init(tracker=utils.TRACKER_PATH)
 
     batch_size = 4
     sampler = g.V('user').batch(batch_size).shuffle(traverse=True).values()
@@ -46,6 +46,8 @@ class NodeIterateTestCase(NodeTestCase):
         break
     ids = range(self.value_range_[0][0], self.value_range_[0][1])
     utils.check_sorted_equal(res_ids, ids)
+
+    g.close()
 
 
 if __name__ == "__main__":

--- a/graphlearn/python/tests/test_node_weighted.py
+++ b/graphlearn/python/tests/test_node_weighted.py
@@ -31,10 +31,12 @@ class WeightedNodeTestCase(NodeTestCase):
     decoder = gl.Decoder(weighted=True)
     g = gl.Graph() \
       .node(source=file_path, node_type=self.node_type_, decoder=decoder)
-    g.init(server_id=0, server_count=1, tracker=utils.TRACKER_PATH)
+    g.init(tracker=utils.TRACKER_PATH)
 
     nodes = g.get_nodes(node_type=self.node_type_, ids=self.ids_)
     self.check_weights(nodes)
+
+    g.close()
 
 
 if __name__ == "__main__":

--- a/graphlearn/python/tests/test_node_weighted_attributed.py
+++ b/graphlearn/python/tests/test_node_weighted_attributed.py
@@ -31,11 +31,13 @@ class WeightedAttributedNodeTestCase(NodeTestCase):
     decoder = gl.Decoder(weighted=True, attr_types=utils.ATTR_TYPES)
     g = gl.Graph() \
       .node(source=file_path, node_type=self.node_type_, decoder=decoder)
-    g.init(server_id=0, server_count=1, tracker=utils.TRACKER_PATH)
+    g.init(tracker=utils.TRACKER_PATH)
 
     nodes = g.get_nodes(node_type=self.node_type_, ids=self.ids_)
     self.check_weights(nodes)
     self.check_attrs(nodes)
+
+    g.close()
 
 
 if __name__ == "__main__":

--- a/graphlearn/python/tests/test_node_weighted_labeled.py
+++ b/graphlearn/python/tests/test_node_weighted_labeled.py
@@ -31,11 +31,13 @@ class WeightedLabeledNodeTestCase(NodeTestCase):
     decoder = gl.Decoder(weighted=True, labeled=True)
     g = gl.Graph() \
       .node(source=file_path, node_type=self.node_type_, decoder=decoder)
-    g.init(server_id=0, server_count=1, tracker=utils.TRACKER_PATH)
+    g.init(tracker=utils.TRACKER_PATH)
 
     nodes = g.get_nodes(node_type=self.node_type_, ids=self.ids_)
     self.check_weights(nodes)
     self.check_labels(nodes)
+
+    g.close()
 
 
 if __name__ == "__main__":

--- a/graphlearn/python/tests/test_node_weighted_labeled_attributed.py
+++ b/graphlearn/python/tests/test_node_weighted_labeled_attributed.py
@@ -33,12 +33,14 @@ class WeightedLabeledAttributedNodeTestCase(NodeTestCase):
         weighted=True, labeled=True, attr_types=utils.ATTR_TYPES)
     g = gl.Graph() \
       .node(source=file_path, node_type=self.node_type_, decoder=decoder)
-    g.init(server_id=0, server_count=1, tracker=utils.TRACKER_PATH)
+    g.init(tracker=utils.TRACKER_PATH)
 
     nodes = g.get_nodes(node_type=self.node_type_, ids=self.ids_)
     self.check_weights(nodes)
     self.check_labels(nodes)
     self.check_attrs(nodes)
+
+    g.close()
 
 
 if __name__ == "__main__":

--- a/graphlearn/python/values.py
+++ b/graphlearn/python/values.py
@@ -271,11 +271,12 @@ class Nodes(Values):
                              np.array(segment_ids, dtype=np.int32),
                              num_segments)
     res = pywrap.new_agg_nodes_res()
-    raise_exception_on_not_ok_status(
-        self.graph.get_client().agg_nodes(req, res))
-    agged = pywrap.get_node_agg_res(res)
+    status = self.graph.get_client().agg_nodes(req, res)
+    if status.ok():
+      agged = pywrap.get_node_agg_res(res)
     pywrap.del_agg_nodes_res(res)
     pywrap.del_agg_nodes_req(req)
+    raise_exception_on_not_ok_status(status)
     return agged
 
   def embedding_agg(self, func="sum"):

--- a/graphlearn/service/call.h
+++ b/graphlearn/service/call.h
@@ -26,7 +26,8 @@ namespace graphlearn {
 
 enum MethodType {
   kUserDefinedOp = 0,
-  kOtherToExtend = 1,
+  kStop = 1,
+  kOtherToExtend = 2,
 };
 
 struct StatusWrapper {

--- a/graphlearn/service/dist/coordinator.cc
+++ b/graphlearn/service/dist/coordinator.cc
@@ -187,10 +187,10 @@ Status Coordinator::Sink(const std::string& sub_dir,
   while (retry < GLOBAL_FLAG(RetryTimes)) {
     s = fs_->CreateDir(tracker_ + sub_dir);
     if (s.ok() || error::IsAlreadyExists(s)) {
-      LOG(INFO) << "Coordinator sink " << sub_dir;
+      LOG(INFO) << "Coordinator sink " << tracker_ << sub_dir;
       break;
     } else {
-      LOG(WARNING) << "Coordinator sink " << sub_dir
+      LOG(WARNING) << "Coordinator sink " << tracker_ << sub_dir
                    << " failed, try " << retry;
     }
     sleep(1 << retry);
@@ -206,7 +206,7 @@ Status Coordinator::Sink(const std::string& sub_dir,
       s = ret->Close();
       break;
     } else {
-      LOG(WARNING) << "Coordinator sink " << sub_dir << file_name
+      LOG(WARNING) << "Coordinator sink " << file_name
                    << " failed, try " << retry;
     }
     sleep(1 << retry);

--- a/graphlearn/service/dist/naming_engine.cc
+++ b/graphlearn/service/dist/naming_engine.cc
@@ -47,6 +47,8 @@ NamingEngine::NamingEngine()
 
   Status s = Env::Default()->GetFileSystem(tracker_, &fs_);
   if (!s.ok()) {
+    USER_LOG("Invalid tracker path and exit now.");
+    USER_LOG(tracker_);
     LOG(FATAL) << "Invalid tracker path: " << tracker_;
     ::exit(-1);
   }
@@ -55,6 +57,8 @@ NamingEngine::NamingEngine()
   if (s.ok() || error::IsAlreadyExists(s)) {
     LOG(INFO) << "Connect naming engine ok: " << tracker_;
   } else {
+    USER_LOG("Connect to tracker path failed and exit now.");
+    USER_LOG(tracker_);
     LOG(FATAL) << "Connect naming engine failed: " << tracker_;
     ::exit(-1);
   }

--- a/graphlearn/service/dist/service.h
+++ b/graphlearn/service/dist/service.h
@@ -29,11 +29,13 @@ class Coordinator;
 class NamingEngine;
 class ChannelManager;
 class GrpcServiceImpl;
+class Coordinator;
 
 class DistributeService {
 public:
   DistributeService(int32_t server_id, int32_t server_count,
-                    Env* env, Executor* executor);
+                    Env* env, Executor* executor,
+                    Coordinator* coord);
   ~DistributeService();
 
   Status Start();

--- a/graphlearn/service/dist/test/service_unittest.cpp
+++ b/graphlearn/service/dist/test/service_unittest.cpp
@@ -57,8 +57,10 @@ TEST_F(DistributeServiceTest, StartInitStop) {
   int32_t server_id = 0;
   int32_t server_count = 1;
 
+  Coordinator* coordinator = new Coordinator(server_id, server_count, env);
+
   DistributeService* service = new DistributeService(
-    server_id, server_count, env, executor);
+    server_id, server_count, env, executor, coordinator);
   Status s = service->Start();
   EXPECT_TRUE(s.ok());
   s = service->Init();
@@ -74,4 +76,5 @@ TEST_F(DistributeServiceTest, StartInitStop) {
   t->join();
   delete t;
   delete service;
+  delete coordinator;
 }

--- a/graphlearn/service/local/in_memory_client_impl.cc
+++ b/graphlearn/service/local/in_memory_client_impl.cc
@@ -15,6 +15,7 @@ limitations under the License.
 
 #include "graphlearn/service/client_impl.h"
 
+#include "graphlearn/include/config.h"
 #include "graphlearn/service/call.h"
 #include "graphlearn/service/local/event_queue.h"
 #include "graphlearn/service/local/in_memory_channel.h"
@@ -40,6 +41,11 @@ public:
   }
 
   Status Stop() override {
+    if (GLOBAL_FLAG(DeployMode) == 2) {
+      StatusWrapper status;
+      channel_->CallMethod(kStop, nullptr, nullptr, &status);
+      return status.s_;
+    }
     return Status::OK();
   }
 

--- a/graphlearn/service/local/in_memory_service.h
+++ b/graphlearn/service/local/in_memory_service.h
@@ -23,10 +23,11 @@ namespace graphlearn {
 class Call;
 class Env;
 class Executor;
+class Coordinator;
 
 class InMemoryService {
 public:
-  InMemoryService(Env* env, Executor* executor);
+  InMemoryService(Env* env, Executor* executor, Coordinator* coord);
   ~InMemoryService();
 
   void Start();
@@ -41,6 +42,7 @@ private:
   Env*         env_;
   Executor*    executor_;
   std::thread* thread_;
+  Coordinator* coord_;
 };
 
 }  // namespace graphlearn

--- a/graphlearn/service/request/graph_update_request.cc
+++ b/graphlearn/service/request/graph_update_request.cc
@@ -66,11 +66,7 @@ UpdateRequest::UpdateRequest(const io::SideInfo* info, int32_t batch_size)
   }
 }
 
-bool UpdateRequest::ParseFrom(const void* request) {
-  if (!OpRequest::ParseFrom(request)) {
-    return false;
-  }
-
+void UpdateRequest::SetMembers() {
   infos_ = &(params_[kSideInfo]);
 
   info_ = new io::SideInfo();
@@ -94,7 +90,6 @@ bool UpdateRequest::ParseFrom(const void* request) {
   if (info_->s_num > 0) {
     s_attrs_ = &(tensors_[kStringAttrKey]);
   }
-  return true;
 }
 
 void UpdateRequest::Append(const io::AttributeValue* value) {
@@ -174,16 +169,13 @@ void UpdateEdgesRequest::SerializeTo(void* request) {
   pb->set_need_server_ready(false);
 }
 
-bool UpdateEdgesRequest::ParseFrom(const void* request) {
-  if (!UpdateRequest::ParseFrom(request)) {
-    return false;
-  }
+void UpdateEdgesRequest::SetMembers() {
+  UpdateRequest::SetMembers();
   info_->type = params_[kEdgeType].GetString(0);
   info_->src_type = params_[kEdgeType].GetString(1);
   info_->dst_type = params_[kEdgeType].GetString(2);
   src_ids_ = &(tensors_[kSrcIds]);
   dst_ids_ = &(tensors_[kDstIds]);
-  return true;
 }
 
 int32_t UpdateEdgesRequest::Size() const {
@@ -250,13 +242,10 @@ void UpdateNodesRequest::SerializeTo(void* request) {
   pb->set_need_server_ready(false);
 }
 
-bool UpdateNodesRequest::ParseFrom(const void* request) {
-  if (!UpdateRequest::ParseFrom(request)) {
-    return false;
-  }
+void UpdateNodesRequest::SetMembers() {
+  UpdateRequest::SetMembers();
   info_->type = params_[kNodeType].GetString(0);
   ids_ = &(tensors_[kNodeIds]);
-  return true;
 }
 
 int32_t UpdateNodesRequest::Size() const {

--- a/graphlearn/service/request/op_request.cc
+++ b/graphlearn/service/request/op_request.cc
@@ -149,6 +149,7 @@ bool OpRequest::ParseFrom(const void* request) {
 
   shardable_ = pb->shardable();
   is_parse_from_ = true;
+  this->SetMembers();
   return true;
 }
 
@@ -212,6 +213,7 @@ bool OpResponse::ParseFrom(const void* response) {
   batch_size_ = params_[kBatchSize].GetInt32(0);
   is_sparse_ = params_[kBatchSize].GetInt32(1) != 0;
   is_parse_from_ = true;
+  this->SetMembers();
   return true;
 }
 
@@ -226,6 +228,7 @@ void OpResponse::Swap(OpResponse& right) {
 void OpResponse::Stitch(ShardsPtr<OpResponse> shards) {
   auto stitcher = GetStitcher(this);
   stitcher->Stitch(shards, this);
+  this->SetMembers();
 }
 
 void RequestFactory::Register(const std::string& name,

--- a/graphlearn/service/server_impl.h
+++ b/graphlearn/service/server_impl.h
@@ -28,6 +28,7 @@ class Executor;
 class GraphStore;
 class InMemoryService;
 class DistributeService;
+class Coordinator;
 
 class ServerImpl {
 public:
@@ -55,6 +56,7 @@ private:
 
   InMemoryService*   in_memory_service_;
   DistributeService* dist_service_;
+  Coordinator*       coordinator_;
 };
 
 }  // namespace graphlearn

--- a/graphlearn/service/test/client_test.cpp
+++ b/graphlearn/service/test/client_test.cpp
@@ -20,32 +20,51 @@ limitations under the License.
 using namespace graphlearn;
 
 void TestGetEdges(Client* client) {
-  GetEdgesRequest req("click", "by_order", 64);
-  GetEdgesResponse res;
-  Status s = client->GetEdges(&req, &res);
-  std::cout << "GetEdges: " << s.ToString() << std::endl;
+  for (int32_t epoch = 0; epoch < 3; ++epoch) {
+    for (int32_t iter = 0; iter < 100; ++iter) {
+      GetEdgesRequest req("click", "by_order", 64, epoch);
+      GetEdgesResponse res;
+      Status s = client->GetEdges(&req, &res);
+      std::cout << "GetEdges: " << s.ToString() << std::endl;
 
-  const int64_t* src_ids = res.SrcIds();
-  const int64_t* dst_ids = res.DstIds();
-  const int64_t* edge_ids = res.EdgeIds();
-  int32_t size = res.Size();
-  std::cout << "Size: " << size << std::endl;
-  for (int32_t i = 0; i < size; ++i) {
-    std::cout << src_ids[i] << ", " << dst_ids[i] << ", " << edge_ids[i] << std::endl;
+      if (!s.ok()) {
+        std::cout << "OutOfRange, epoch:" << epoch << std::endl;
+        break;
+      }
+
+      const int64_t* src_ids = res.SrcIds();
+      const int64_t* dst_ids = res.DstIds();
+      const int64_t* edge_ids = res.EdgeIds();
+      int32_t size = res.Size();
+      std::cout << "Size: " << size << std::endl;
+      if (epoch == 0 && iter == 0) {
+        for (int32_t i = 0; i < size; ++i) {
+          std::cout << src_ids[i] << ", " << dst_ids[i] << ", " << edge_ids[i] << std::endl;
+        }
+      }
+    }
   }
 }
 
 void TestGetNodes(Client* client) {
-  GetNodesRequest req("user", "by_order", NodeFrom::kNode, 64);
-  GetNodesResponse res;
-  Status s = client->GetNodes(&req, &res);
-  std::cout << "GetNodes: " << s.ToString() << std::endl;
+  for (int32_t epoch = 0; epoch < 3; ++epoch) {
+    for (int32_t iter = 0; iter < 10; ++iter) {
+      GetNodesRequest req("user", "by_order", NodeFrom::kNode, 64, epoch);
+      GetNodesResponse res;
+      Status s = client->GetNodes(&req, &res);
+      std::cout << "GetNodes: " << s.ToString() << std::endl;
 
-  const int64_t* node_ids = res.NodeIds();
-  int32_t size = res.Size();
-  std::cout << "Size: " << size << std::endl;
-  for (int32_t i = 0; i < size; ++i) {
-    std::cout << node_ids[i] << std::endl;
+      if (!s.ok()) {
+        std::cout << "OutOfRange, epoch:" << epoch << std::endl;
+        break;
+      }
+      const int64_t* node_ids = res.NodeIds();
+      int32_t size = res.Size();
+      std::cout << "Size: " << size << std::endl;
+      for (int32_t i = 0; i < size; ++i) {
+        std::cout << node_ids[i] << std::endl;
+      }
+    }
   }
 }
 
@@ -235,7 +254,7 @@ void TestRandomSampleNeighbors(Client* client) {
 
   SamplingResponse res;
   Status s = client->Sampling(&req, &res);
-  std::cout << "SampleNeighbors: " << s.ToString() << std::endl;
+  std::cout << "RandomSampleNeighbors: " << s.ToString() << std::endl;
 
   const int64_t* nbrs = res.GetNeighborIds();
   int32_t size = res.TotalNeighborCount();

--- a/graphlearn/service/test/dist_in_memory_test.cpp
+++ b/graphlearn/service/test/dist_in_memory_test.cpp
@@ -1,0 +1,379 @@
+/* Copyright 2020 Alibaba Group Holding Limited. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include <cstring>
+#include <fstream>
+#include <iostream>
+#include <string>
+#include "graphlearn/core/io/element_value.h"
+#include "graphlearn/include/server.h"
+#include "graphlearn/include/config.h"
+#include "graphlearn/include/client.h"
+
+using namespace graphlearn;
+
+void TestGetEdges(Client* client) {
+  GetEdgesRequest req("click", "by_order", 64);
+  GetEdgesResponse res;
+  Status s = client->GetEdges(&req, &res);
+  std::cout << "GetEdges: " << s.ToString() << std::endl;
+
+  const int64_t* src_ids = res.SrcIds();
+  const int64_t* dst_ids = res.DstIds();
+  const int64_t* edge_ids = res.EdgeIds();
+  int32_t size = res.Size();
+  std::cout << "Size: " << size << std::endl;
+  for (int32_t i = 0; i < size; ++i) {
+    std::cout << src_ids[i] << ", " << dst_ids[i] << ", " << edge_ids[i] << std::endl;
+  }
+}
+
+void TestGetNodes(Client* client) {
+  GetNodesRequest req("user", "by_order", NodeFrom::kNode, 64);
+  GetNodesResponse res;
+  Status s = client->GetNodes(&req, &res);
+  std::cout << "GetNodes: " << s.ToString() << std::endl;
+
+  const int64_t* node_ids = res.NodeIds();
+  int32_t size = res.Size();
+  std::cout << "Size: " << size << std::endl;
+  for (int32_t i = 0; i < size; ++i) {
+    std::cout << node_ids[i] << std::endl;
+  }
+}
+
+void TestLookupNodes(Client* client) {
+  LookupNodesRequest req("movie");
+  int64_t ids[10] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+  req.Set(ids, 10);
+
+  LookupNodesResponse res;
+  Status s = client->LookupNodes(&req, &res);
+  std::cout << "LookupNodes: " << s.ToString() << std::endl;
+
+  int32_t size = res.Size();
+  int32_t format = res.Format();
+  std::cout << "Size: " << size << ", format: " << format << std::endl;
+  if (res.Format() & io::DataFormat::kWeighted) {
+    const float* weights = res.Weights();
+    std::cout << "weights: ";
+    for (int32_t i = 0; i < size; ++i) {
+      std::cout << weights[i] << ' ';
+    }
+    std::cout << std::endl;
+  }
+  if (res.Format() & io::DataFormat::kLabeled) {
+    const int32_t* labels = res.Labels();
+    std::cout << "labels: ";
+    for (int32_t i = 0; i < size; ++i) {
+      std::cout << labels[i] << ' ';
+    }
+    std::cout << std::endl;
+  }
+  if (res.Format() & io::DataFormat::kAttributed) {
+    if (res.IntAttrNum() > 0) {
+      int32_t int_num = res.IntAttrNum();
+      const int64_t* ints = res.IntAttrs();
+      std::cout << "ints: ";
+      for (int32_t i = 0; i < size * int_num; ++i) {
+        std::cout << ints[i] << ' ';
+      }
+      std::cout << std::endl;
+    }
+    if (res.FloatAttrNum() > 0) {
+      int32_t float_num = res.FloatAttrNum();
+      const float* floats = res.FloatAttrs();
+      std::cout << "floats: ";
+      for (int32_t i = 0; i < size * float_num; ++i) {
+        std::cout << floats[i] << ' ';
+      }
+      std::cout << std::endl;
+    }
+    if (res.StringAttrNum() > 0) {
+      int32_t str_num = res.StringAttrNum();
+      const std::string* strs = res.StringAttrs();
+      std::cout << "strings: ";
+      for (int32_t i = 0; i < size * str_num; ++i) {
+        std::cout << strs[i] << ' ';
+      }
+      std::cout << std::endl;
+    }
+  }
+}
+
+void TestSumAggregateNodes(Client* client) {
+  AggregatingRequest req("movie", "SumAggregator");
+  int64_t ids[10] = {0,  1, 2,  3, 4, 5,  6, 7, 8, 9};
+  int32_t segment_ids[10] = {0, 1, 1, 2, 2, 2, 3, 3, 3, 3};
+  int32_t num_segments = 4;
+  req.Set(ids, segment_ids, 10, 4);
+
+  AggregatingResponse res;
+  Status s = client->Aggregating(&req, &res);
+  std::cout << "SumAggregateNodes: " << s.ToString() << std::endl;
+
+  int32_t size = res.NumSegments();
+
+  if (res.EmbeddingDim() > 0) {
+    int32_t float_num = res.EmbeddingDim();
+    const float* floats = res.Embeddings();
+    std::cout << "floats: ";
+    for (int32_t i = 0; i < size * float_num; ++i) {
+      std::cout << floats[i] << ' ';
+    }
+    std::cout << std::endl;
+  }
+}
+
+void TestRandomSampleNeighbors(Client* client) {
+  SamplingRequest req("click", "RandomSampler", 3);
+  int64_t ids[10] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+  req.Set(ids, 10);
+
+  SamplingResponse res;
+  Status s = client->Sampling(&req, &res);
+  std::cout << "SampleNeighbors: " << s.ToString() << std::endl;
+
+  const int64_t* nbrs = res.GetNeighborIds();
+  int32_t size = res.TotalNeighborCount();
+  std::cout << "TotalNeighborCount: " << size << std::endl;
+  for (int32_t i = 0; i < size; ++i) {
+    std::cout << nbrs[i] << std::endl;
+  }
+}
+
+void GenEdgeSource(io::EdgeSource* source, int32_t format,
+                   const std::string& file_name,
+                   const std::string& edge_type,
+                   const std::string& src_type,
+                   const std::string& dst_type) {
+  source->path = file_name;
+  source->edge_type = edge_type;
+  source->src_id_type = src_type;
+  source->dst_id_type = dst_type;
+  source->format = format;
+  source->ignore_invalid = false;
+  if (format & io::kAttributed) {
+    source->delimiter = ":";
+    source->types = {DataType::kInt32, DataType::kInt32, DataType::kFloat, DataType::kString};
+    source->hash_buckets = {0, 0, 0, 0};
+  }
+}
+
+void GenNodeSource(io::NodeSource* source, int32_t format,
+                   const std::string& file_name,
+                   const std::string& node_type) {
+  source->path = file_name;
+  source->id_type = node_type;
+  source->format = format;
+  source->ignore_invalid = false;
+  if (format & io::kAttributed) {
+    source->delimiter = ":";
+    source->types = {DataType::kInt32, DataType::kInt32, DataType::kFloat, DataType::kString};
+    source->hash_buckets = {0, 0, 0, 0};
+  }
+}
+
+void GenEdgeTestData(const char* file_name, int32_t format) {
+  io::SideInfo info;
+  info.format = format;
+
+  std::ofstream out(file_name);
+
+  // write title
+  if (info.IsWeighted() && info.IsLabeled() && info.IsAttributed()) {
+    const char* title = "src_id:int64\tdst_id:int64\tedge_weight:float\tlabel:int32\tattribute:string\n";
+    out.write(title, strlen(title));
+  } else if (info.IsWeighted() && info.IsLabeled()) {
+    const char* title = "src_id:int64\tdst_id:int64\tedge_weight:float\tlabel:int32\n";
+    out.write(title, strlen(title));
+  } else if (info.IsWeighted() && info.IsAttributed()) {
+    const char* title = "src_id:int64\tdst_id:int64\tedge_weight:float\tattribute:string\n";
+    out.write(title, strlen(title));
+  } else if (info.IsLabeled() && info.IsAttributed()) {
+    const char* title = "src_id:int64\tdst_id:int64\tlabel:int32\tattribute:string\n";
+    out.write(title, strlen(title));
+  } else if (info.IsWeighted()) {
+    const char* title = "src_id:int64\tdst_id:int64\tedge_weight:float\n";
+    out.write(title, strlen(title));
+  } else if (info.IsLabeled()) {
+    const char* title = "src_id:int64\tdst_id:int64\tlabel:int32\n";
+    out.write(title, strlen(title));
+  } else {
+    const char* title = "src_id:int64\tdst_id:int64\tattribute:string\n";
+    out.write(title, strlen(title));
+  }
+
+  // write data
+  int size = 0;
+  char buffer[64];
+  for (int32_t i = 0; i < 100; ++i) {
+    if (info.IsWeighted() && info.IsLabeled() && info.IsAttributed()) {
+      size = snprintf(buffer, sizeof(buffer),
+                      "%d\t%d\t%f\t%d\t%d:%d:%f:%c\n",
+                      i, i, float(i), i, i, i*10, float(i), char(i % 26 + 'A'));
+    } else if (info.IsWeighted() && info.IsLabeled()) {
+      size = snprintf(buffer, sizeof(buffer),
+                      "%d\t%d\t%f\t%d\n", i, i, float(i), i);
+    } else if (info.IsWeighted() && info.IsAttributed()) {
+      size = snprintf(buffer, sizeof(buffer),
+                      "%d\t%d\t%f\t%d:%d:%f:%c\n",
+                      i, i, float(i), i, i*10, float(i), char(i % 26 + 'A'));
+    } else if (info.IsLabeled() && info.IsAttributed()) {
+      size = snprintf(buffer, sizeof(buffer),
+                      "%d\t%d\t%d\t%d:%d:%f:%c\n",
+                      i, i, i, i, i*10, float(i), char(i % 26 + 'A'));
+    } else if (info.IsWeighted()) {
+      size = snprintf(buffer, sizeof(buffer), "%d\t%d\t%f\n", i, i, float(i));
+    } else if (info.IsLabeled()) {
+      size = snprintf(buffer, sizeof(buffer), "%d\t%d\t%d\n", i, i, i);
+    } else {
+      size = snprintf(buffer, sizeof(buffer),
+                      "%d\t%d\t%d:%d:%f:%c\n",
+                      i, i, i, i*10, float(i), char(i % 26 + 'A'));
+    }
+    out.write(buffer, size);
+  }
+  out.close();
+}
+
+void GenNodeTestData(const char* file_name, int32_t format) {
+  io::SideInfo info;
+  info.format = format;
+
+  std::ofstream out(file_name);
+
+  // write title
+  if (info.IsWeighted() && info.IsLabeled() && info.IsAttributed()) {
+    const char* title = "node_id:int64\tnode_weight:float\tlabel:int32\tattribute:string\n";
+    out.write(title, strlen(title));
+  } else if (info.IsWeighted() && info.IsLabeled()) {
+    const char* title = "node_id:int64\tnode_weight:float\tlabel:int32\n";
+    out.write(title, strlen(title));
+  } else if (info.IsWeighted() && info.IsAttributed()) {
+    const char* title = "node_id:int64\tnode_weight:float\tattribute:string\n";
+    out.write(title, strlen(title));
+  } else if (info.IsLabeled() && info.IsAttributed()) {
+    const char* title = "node_id:int64\tlabel:int32\tattribute:string\n";
+    out.write(title, strlen(title));
+  } else if (info.IsWeighted()) {
+    const char* title = "node_id:int64\tnode_weight:float\n";
+    out.write(title, strlen(title));
+  } else if (info.IsLabeled()) {
+    const char* title = "node_id:int64\tlabel:int32\n";
+    out.write(title, strlen(title));
+  } else {
+    const char* title = "node_id:int64\tattribute:string\n";
+    out.write(title, strlen(title));
+  }
+
+  // write data
+  int size = 0;
+  char buffer[64];
+  for (int32_t i = 0; i < 100; ++i) {
+    if (info.IsWeighted() && info.IsLabeled() && info.IsAttributed()) {
+      size = snprintf(buffer, sizeof(buffer),
+                      "%d\t%f\t%d\t%d:%d:%f:%c\n",
+                      i, float(i), i, i, i*10, float(i), char(i % 26 + 'A'));
+    } else if (info.IsWeighted() && info.IsLabeled()) {
+      size = snprintf(buffer, sizeof(buffer),
+                      "%d\t%f\t%d\n", i, float(i), i);
+    } else if (info.IsWeighted() && info.IsAttributed()) {
+      size = snprintf(buffer, sizeof(buffer),
+                      "%d\t%f\t%d:%d:%f:%c\n",
+                      i, float(i), i, i*10, float(i), char(i % 26 + 'A'));
+    } else if (info.IsLabeled() && info.IsAttributed()) {
+      size = snprintf(buffer, sizeof(buffer),
+                      "%d\t%d\t%d:%d:%f:%c\n",
+                      i, i, i, i*10, float(i), char(i % 26 + 'A'));
+    } else if (info.IsWeighted()) {
+      size = snprintf(buffer, sizeof(buffer), "%d\t%f\n", i, float(i));
+    } else if (info.IsLabeled()) {
+      size = snprintf(buffer, sizeof(buffer), "%d\t%d\n", i, i);
+    } else {
+      size = snprintf(buffer, sizeof(buffer),
+                      "%d\t%d:%d:%f:%c\n",
+                      i, i, i*10, float(i), char(i % 26 + 'A'));
+    }
+    out.write(buffer, size);
+  }
+  out.close();
+}
+
+int main(int argc, char** argv) {
+  ::system("mkdir -p ./tracker");
+
+  int32_t server_id = 0;
+  int32_t server_count = 1;
+  if (argc == 1) {
+  } else if (argc > 2) {
+    server_id = argv[1][0] - '0';
+    server_count = argv[2][0] - '0';
+  } else {
+    std::cout << "./dist_in_memory_test [server_id] [server_count]" << std::endl;
+    std::cout << "e.g. ./dist_in_memory_test 0 2" << std::endl;
+    return -1;
+  }
+
+  SetGlobalFlagDeployMode(2);
+
+  SetGlobalFlagClientId(server_id);
+  SetGlobalFlagClientCount(server_count);
+  SetGlobalFlagServerCount(server_count);
+  SetGlobalFlagTracker("./tracker");
+
+  Server* server = NewServer(server_id, server_count, "./tracker");
+  server->Start();
+  std::cout << server_id << "th in " << server_count << " server started" << std::endl;
+
+  GenEdgeTestData("weighted_edge_file", io::kWeighted);
+  GenEdgeTestData("labeled_edge_file", io::kLabeled);
+  GenEdgeTestData("attributed_edge_file", io::kAttributed);
+
+  std::vector<io::EdgeSource> edges(3);
+  GenEdgeSource(&edges[0], io::kWeighted, "weighted_edge_file", "click", "user", "item");
+  GenEdgeSource(&edges[1], io::kLabeled, "labeled_edge_file", "buy", "user", "item");
+  GenEdgeSource(&edges[2], io::kAttributed, "attributed_edge_file", "watch", "user", "movie");
+
+  GenNodeTestData("weighted_node_file", io::kWeighted);
+  GenNodeTestData("labeled_node_file", io::kLabeled);
+  GenNodeTestData("attributed_node_file", io::kAttributed);
+
+  std::vector<io::NodeSource> nodes(3);
+  GenNodeSource(&nodes[0], io::kWeighted, "weighted_node_file", "user");
+  GenNodeSource(&nodes[1], io::kLabeled, "labeled_node_file", "item");
+  GenNodeSource(&nodes[2], io::kAttributed, "attributed_node_file", "movie");
+
+  server->Init(edges, nodes);
+  std::cout << "Inited" << std::endl;
+
+  Client* client = NewInMemoryClient();
+
+  TestGetEdges(client);
+  TestGetNodes(client);
+  TestLookupNodes(client);
+  TestSumAggregateNodes(client);
+  TestRandomSampleNeighbors(client);
+
+  client->Stop();
+  std::cout << "InMemory Client Stopped" << std::endl;
+  delete client;
+
+  server->Stop();
+  std::cout << "Stopped" << std::endl;
+  delete server;
+
+  return 0;
+}


### PR DESCRIPTION
# Deploy Mode
Graph Engine(Server) and NN Engine(Client) are deployed either seperated and colocated.
## ServiceMode
Graph Engine(Server) and NN Engine(Client) are deployed seperated.
Usage:
```python
""" -------------On server---------- """
import graphlearn as gl
cluster_spec={"server_count": 2, "client_count": 4, "tracker": "/mnt/tracker"}
g = gl.Graph().init(cluster=cluster_spec, job_name="server", task_index=1)
# cluster: a dict contains total number of servers, total number of clients and a tracker path
# job_name: "server"
# task_index: 0 to server_count-1
g.wait_for_close()

""" -------------On client---------- """
import graphlearn as gl
cluster_spec={"server_count": 2, "client_count": 4, "tracker": "/mnt/tracker"}
g = gl.Graph().init(cluster=cluster_spec, job_name="client", task_index=3)
# cluster: a dict contains total number of servers, total number of clients and a tracker path
# job_name: "client"
# task_index: 0 to client_count-1

# g.V()...   # do some query or sampling on graph
g.close()
```

## TaskMode
Graph Engine(Server) and NN Engine(Client) are deployed colocated.
Usage:
```python
import graphlearn as gl
g = gl.Graph().init(task_index=0, task_count=3, tracker="/mnt/tracker")
# task_index: 0 to task_count-1
# task_count: total count of tasks

# g.V()...   # do some query or sampling on graph
g.close()
```
# Bug fix
Fix bug of iterating nodes or edges with several epochs with ServiceMode when count of clients is bigger than count of servers. 