### PR TITLE
Use OID, and optimize attribute traversal.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,7 @@ option (TESTING "ENABLE testing" OFF)
 option (GL_DEBUG "Enable debug mode" OFF)
 option (PROFILING "Enable profiling" OFF)
 option (WITH_VINEYARD "Enable vineyard" OFF)
+option (VINEYARD_USE_OID "Use OID when work with vineyard graphs" ON)
 set (PYTHON_VERSION
     "python3"
     CACHE
@@ -190,6 +191,9 @@ if(WITH_VINEYARD)
     find_package(vineyard)
     include_directories(SYSTEM ${VINEYARD_INCLUDE_DIRS})
     add_definitions(-DWITH_VINEYARD)
+    if (VINEYARD_USE_OID)
+        add_definitions(-DVINEYARD_USE_OID)
+    endif()
 endif()
 
 # proto
@@ -240,8 +244,10 @@ file (GLOB_RECURSE SERVICE_FILES
 
 
 if (GL_DEBUG)
+    set (CMAKE_BUILD_TYPE "Debug")
     set (MODEFLAGS -DDEBUG -g)
 else()
+    set (CMAKE_BUILD_TYPE "Release")
     set (MODEFLAGS -DNDEBUG -O2)
 endif()
 

--- a/graphlearn/core/graph/storage/vineyard_edge_storage.h
+++ b/graphlearn/core/graph/storage/vineyard_edge_storage.h
@@ -66,7 +66,8 @@ public:
       boost::algorithm::split(attrs_, use_attrs, boost::is_any_of(";"));
     }
 
-    init_src_dst_list(frag_, edge_label_, src_lists_, dst_lists_);
+    init_src_dst_list(frag_, edge_label_,
+                      src_lists_, dst_lists_, edge_lists_);
     side_info_ = frag_edge_side_info(frag_, attrs_, edge_label_);
   }
 
@@ -196,6 +197,7 @@ private:
 
   std::vector<IdType> src_lists_;
   std::vector<IdType> dst_lists_;
+  std::vector<IdType> edge_lists_;
 };
 
 } // namespace io

--- a/graphlearn/core/graph/storage/vineyard_graph_storage.h
+++ b/graphlearn/core/graph/storage/vineyard_graph_storage.h
@@ -48,6 +48,7 @@ public:
     if (frag_ == nullptr) {
       throw std::runtime_error("Graph: failed to find a local fragment");
     }
+    vertex_map_ = frag_->GetVertexMap();
 
     if (!edge_view.empty()) {
       std::vector<std::string> args;
@@ -77,7 +78,8 @@ public:
       boost::algorithm::split(attrs_, use_attrs, boost::is_any_of(";"));
     }
 
-    init_src_dst_list(frag_, edge_label_, src_lists_, dst_lists_);
+    init_src_dst_list(frag_, edge_label_,
+                      src_lists_, dst_lists_, edge_lists_);
     side_info_ = frag_edge_side_info(frag_, attrs_, edge_label_);
   }
 
@@ -104,37 +106,71 @@ public:
     return get_edge_dst_id(frag_, edge_label_, dst_lists_, edge_id);
   }
   virtual float GetEdgeWeight(IdType edge_id) const override {
-    if (!side_info_->IsWeighted()) {
+    if (!side_info_->IsWeighted() || edge_id >= edge_lists_.size()) {
       return -1;
     }
-    return get_edge_weight(frag_, edge_label_, edge_id);
+    return get_edge_weight(frag_, edge_label_, edge_lists_[edge_id]);
   }
   virtual int32_t GetEdgeLabel(IdType edge_id) const override {
-    if (!side_info_->IsLabeled()) {
+    if (!side_info_->IsLabeled() || edge_id >= edge_lists_.size()) {
       return -1;
     }
-    return get_edge_label(frag_, edge_label_, edge_id);
+    return get_edge_label(frag_, edge_label_, edge_lists_[edge_id]);
   }
   virtual Attribute GetEdgeAttribute(IdType edge_id) const override {
-    if (!side_info_->IsAttributed()) {
+    if (!side_info_->IsAttributed() || edge_id >= edge_lists_.size()) {
       return Attribute();
     }
-    return get_edge_attribute(frag_, edge_label_, edge_id, attrs_);
+    return get_edge_attribute(frag_, edge_label_, edge_lists_[edge_id], attrs_);
   }
 
   virtual Array<IdType> GetNeighbors(IdType src_id) const override {
-    return get_all_outgoing_neighbor_nodes(frag_, src_id, edge_label_);
+#if defined(VINEYARD_USE_OID)
+    vineyard_vid_t src_gid;
+    if (!vertex_map_->GetGid(frag_->fid(), /* node_label_, */ src_id, src_gid)) {
+      return IdArray();
+    }
+#else
+    vineyard_vid_t src_gid = static_cast<vineyard_vid_t>(src_id);
+#endif
+    return get_all_outgoing_neighbor_nodes(frag_, dst_lists_, src_gid, edge_label_);
   }
+
   virtual Array<IdType> GetOutEdges(IdType src_id) const override {
-    return get_all_outgoing_neighbor_edges(frag_, src_id, edge_label_);
+#if defined(VINEYARD_USE_OID)
+    vineyard_vid_t src_gid;
+    if (!vertex_map_->GetGid(frag_->fid(), /* node_label_, */ src_id, src_gid)) {
+      return IdArray();
+    }
+#else
+    vineyard_vid_t src_gid = static_cast<vineyard_vid_t>(src_id);
+#endif
+    return get_all_outgoing_neighbor_edges(frag_, edge_lists_, src_gid, edge_label_);
   }
 
   virtual IndexType GetInDegree(IdType dst_id) const override {
-    return frag_->GetLocalInDegree(vertex_t{static_cast<uint64_t>(dst_id)},
+#if defined(VINEYARD_USE_OID)
+    vineyard_vid_t dst_gid;
+    if (!vertex_map_->GetGid(frag_->fid(), /* node_label_, */ dst_id, dst_gid)) {
+      return -1;
+    }
+#else
+    vineyard_vid_t dst_gid = static_cast<vineyard_vid_t>(dst_id);
+#endif
+    return frag_->GetLocalInDegree(vertex_t{static_cast<uint64_t>(dst_gid)},
                                    edge_label_);
   }
+
   virtual IndexType GetOutDegree(IdType src_id) const override {
-    return frag_->GetLocalOutDegree(vertex_t{static_cast<uint64_t>(src_id)},
+#if defined(VINEYARD_USE_OID)
+    vineyard_vid_t src_gid;
+    if (!vertex_map_->GetGid(frag_->fid(), /* node_label_, */ src_id, src_gid)) {
+      return -1;
+    }
+#else
+    vineyard_vid_t src_gid = static_cast<vineyard_vid_t>(src_id);
+#endif
+    return frag_->GetLocalOutDegree(vertex_t{static_cast<uint64_t>(src_gid)},
                                     edge_label_);
   }
   virtual const IndexList *GetAllInDegrees() const override {
@@ -164,6 +200,9 @@ private:
 
   std::vector<IdType> src_lists_;
   std::vector<IdType> dst_lists_;
+  std::vector<IdType> edge_lists_;
+
+  std::shared_ptr<gl_frag_t::vertex_map_t> vertex_map_;
 };
 
 } // namespace io

--- a/graphlearn/core/graph/storage/vineyard_graph_storage.h
+++ b/graphlearn/core/graph/storage/vineyard_graph_storage.h
@@ -118,8 +118,11 @@ public:
     return get_edge_label(frag_, edge_label_, edge_lists_[edge_id]);
   }
   virtual Attribute GetEdgeAttribute(IdType edge_id) const override {
-    if (!side_info_->IsAttributed() || edge_id >= edge_lists_.size()) {
+    if (!side_info_->IsAttributed()) {
       return Attribute();
+    }
+    if (edge_id >= edge_lists_.size()) {
+      return Attribute(AttributeValue::Default(side_info_), false);
     }
     return get_edge_attribute(frag_, edge_label_, edge_lists_[edge_id], attrs_);
   }

--- a/graphlearn/core/graph/storage/vineyard_node_storage.h
+++ b/graphlearn/core/graph/storage/vineyard_node_storage.h
@@ -206,7 +206,7 @@ public:
 #if defined(VINEYARD_USE_OID)
     vineyard_vid_t node_gid;
     if (!vertex_map_->GetGid(frag_->fid(), node_label_, node_id, node_gid)) {
-      return Attribute();
+      return Attribute(AttributeValue::Default(side_info_), false);
     }
 #else
     vineyard_vid_t node_gid = static_cast<vineyard_vid_t>(node_id);
@@ -234,9 +234,11 @@ public:
         offset, i32_indexes_, i64_indexes_, f32_indexes_, f64_indexes_,
         s_indexes_, ls_indexes_, vertex_table_accessors_), true);
 #else
-    return Attribute(new ArrowRefAttributeValue(
-        offset, i32_indexes_, i64_indexes_, f32_indexes_, f64_indexes_,
-        s_indexes_, ls_indexes_, vertex_table_accessors_), true);
+    thread_local ArrowRefAttributeValue attribute(
+        0, i32_indexes_, i64_indexes_, f32_indexes_, f64_indexes_,
+        s_indexes_, ls_indexes_, vertex_table_accessors_);
+    attribute.Reuse(offset);
+    return Attribute(&attribute, false);
 #endif
   }
 

--- a/graphlearn/core/graph/storage/vineyard_storage_utils.h
+++ b/graphlearn/core/graph/storage/vineyard_storage_utils.h
@@ -153,6 +153,10 @@ public:
   ~ArrowRefAttributeValue() override {
   }
 
+  void Reuse(const int row_index) {
+    row_index_ = row_index;
+  }
+
   void Clear() override {
   }
 

--- a/graphlearn/core/graph/storage/vineyard_storage_utils.h
+++ b/graphlearn/core/graph/storage/vineyard_storage_utils.h
@@ -84,6 +84,16 @@ const Array<IdType>
 get_all_outgoing_neighbor_edges(std::shared_ptr<gl_frag_t> const &frag,
                                 IdType src_id, const label_id_t edge_label);
 
+const Array<IdType>
+get_all_outgoing_neighbor_nodes(std::shared_ptr<gl_frag_t> const &frag,
+                                std::vector<IdType> const &edge_lists,
+                                IdType src_id, const label_id_t edge_label);
+
+const Array<IdType>
+get_all_outgoing_neighbor_edges(std::shared_ptr<gl_frag_t> const &frag,
+                                std::vector<IdType> const &edge_lists,
+                                IdType src_id, const label_id_t edge_label);
+
 IdType get_edge_src_id(std::shared_ptr<gl_frag_t> const &frag,
                        label_id_t const edge_label,
                        std::vector<IdType> const &src_ids, IdType edge_id);
@@ -93,19 +103,21 @@ IdType get_edge_dst_id(std::shared_ptr<gl_frag_t> const &frag,
                        std::vector<IdType> const &dst_ids, IdType edge_id);
 
 float get_edge_weight(std::shared_ptr<gl_frag_t> const &frag,
-                      label_id_t const edge_label, IdType edge_id);
+                      label_id_t const edge_label, IdType edge_offset);
 
 int32_t get_edge_label(std::shared_ptr<gl_frag_t> const &frag,
-                       label_id_t const edge_label, IdType edge_id);
+                       label_id_t const edge_label, IdType edge_offset);
 
 Attribute get_edge_attribute(std::shared_ptr<gl_frag_t> const &frag,
                              label_id_t const edge_label,
-                             IdType edge_id,
+                             IdType edge_offset,
                              std::set<std::string> const &attrs);
 
 void init_src_dst_list(std::shared_ptr<gl_frag_t> const &frag,
-                    label_id_t const edge_label, std::vector<IdType> &src_lists,
-                    std::vector<IdType> &dst_lists);
+                       label_id_t const edge_label,
+                       std::vector<IdType> &src_lists,
+                       std::vector<IdType> &dst_lists,
+                       std::vector<IdType> &edge_lists);
 
 SideInfo *frag_edge_side_info(std::shared_ptr<gl_frag_t> const &frag,
                               std::set<std::string> const &attrs,

--- a/graphlearn/core/graph/storage/vineyard_storage_utils.h
+++ b/graphlearn/core/graph/storage/vineyard_storage_utils.h
@@ -223,7 +223,7 @@ public:
   void FillStrings(Tensor* tensor) const override;
 
 private:
-	const int row_index_;
+	int row_index_;
   const std::vector<int> &i32_indexes_;
   const std::vector<int> &i64_indexes_;
   const std::vector<int> &f32_indexes_;

--- a/graphlearn/core/graph/storage/vineyard_topo_storage.h
+++ b/graphlearn/core/graph/storage/vineyard_topo_storage.h
@@ -65,7 +65,8 @@ public:
       boost::algorithm::split(attrs_, use_attrs, boost::is_any_of(";"));
     }
 
-    init_src_dst_list(frag_, edge_label_, src_lists_, dst_lists_);
+    init_src_dst_list(frag_, edge_label_,
+                      src_lists_, dst_lists_, edge_lists_);
   }
 
   virtual ~VineyardTopoStorage() = default;
@@ -141,6 +142,7 @@ private:
 
   std::vector<IdType> src_lists_;
   std::vector<IdType> dst_lists_;
+  std::vector<IdType> edge_lists_;
 };
 
 } // namespace io


### PR DESCRIPTION
Note that the performance bottleneck is in the cast from `double` to `float`.