### PR TITLE
make bipartite_graphsage model runnable in graphscope

### DIFF
--- a/graphlearn/python/graph.py
+++ b/graphlearn/python/graph.py
@@ -112,9 +112,15 @@ class Graph(object):
       src_node_type = confs[0]
       edge_type = confs[1]
       dst_node_type = confs[2]
-      if edges is not None and [src_node_type, edge_type, dst_node_type] not in edges \
-        and (src_node_type, edge_type, dst_node_type) not in edges:
-        continue
+      directed = True
+      if edges is not None:
+        orig_edges = [list(e[0:3]) for e in edges]
+        e = [src_node_type, edge_type, dst_node_type]
+        if e not in orig_edges:
+          continue
+        index = orig_edges.index(e)
+        if len(edge[index]) == 4:
+          directed = edge[index][3]
       weighted = confs[3] == 'true'
       labeled = confs[4] == 'true'
       n_int = int(confs[5])
@@ -123,7 +129,8 @@ class Graph(object):
       self.edge(source='',
                 edge_type=(src_node_type, dst_node_type, edge_type),
                 decoder=self._make_vineyard_decoder(
-                  weighted, labeled, n_int, n_float, n_string))
+                  weighted, labeled, n_int, n_float, n_string),
+                directed = directed)
 
     return self
 

--- a/graphlearn/python/graph.py
+++ b/graphlearn/python/graph.py
@@ -112,15 +112,11 @@ class Graph(object):
       src_node_type = confs[0]
       edge_type = confs[1]
       dst_node_type = confs[2]
-      directed = True
-      if edges is not None:
-        orig_edges = [list(e[0:3]) for e in edges]
-        e = [src_node_type, edge_type, dst_node_type]
-        if e not in orig_edges:
-          continue
-        index = orig_edges.index(e)
-        if len(edge[index]) == 4:
-          directed = edge[index][3]
+      if edges is not None and [src_node_type, edge_type, dst_node_type] not in edges \
+        and (src_node_type, edge_type, dst_node_type) not in edges:
+        continue
+      if 'reverse' not in edge_type:
+        self._undirected_edges.append(edge_type)
       weighted = confs[3] == 'true'
       labeled = confs[4] == 'true'
       n_int = int(confs[5])
@@ -129,8 +125,7 @@ class Graph(object):
       self.edge(source='',
                 edge_type=(src_node_type, dst_node_type, edge_type),
                 decoder=self._make_vineyard_decoder(
-                  weighted, labeled, n_int, n_float, n_string),
-                directed = directed)
+                  weighted, labeled, n_int, n_float, n_string))
 
     return self
 


### PR DESCRIPTION
load graph example:
```python
vertices = {
  "u": ("u2i_node_attrs", ["feature"], 'id'),
  "u": ("u2i_node_attrs", ["feature"], 'id'),
}
edges = {
  "u-i": (
      "u2i_20200222_train",
      ["weight"],
      ("src_id", "u"),
      ("dst_id", "i"),
  ),
  "u-i_reverse": (
      "u2i_20200222_train",
      ["weight"],
      ("dst_id", "i"),
      ("src_id", "u"),
  ),
}
g = sess.load_from(edges, vertices)
lg = sess.learning(g, nodes=[("u", ["feature"]), ("i", ["feature"])])
```

