### PR TITLE
Gain the lock to avoid `stop` and `refresh` at the same time.

### DIFF
--- a/graphlearn/service/dist/channel_manager.cc
+++ b/graphlearn/service/dist/channel_manager.cc
@@ -77,6 +77,7 @@ void ChannelManager::SetCapacity(int32_t capacity) {
 }
 
 void ChannelManager::Stop() {
+  ScopedLocker<std::mutex> _(&mtx_);
   bool to_stop = true;
   for (size_t i = 0; i < channels_.size(); ++i) {
     if (!channels_[i]->IsStopped()) {
@@ -149,6 +150,7 @@ std::string ChannelManager::GetEndpoint(int32_t server_id) {
 
 void ChannelManager::Refresh() {
   while (!stopped_) {
+    ScopedLocker<std::mutex> _(&mtx_);
     for (size_t i = 0; i < channels_.size(); ++i) {
       if (channels_[i] && channels_[i]->IsBroken()) {
         std::string endpoint = engine_->Get(i);

--- a/graphlearn/service/dist/channel_manager.h
+++ b/graphlearn/service/dist/channel_manager.h
@@ -51,7 +51,7 @@ private:
 
 private:
   std::mutex    mtx_;
-  bool          stopped_;
+  std::atomic<bool> stopped_;
   NamingEngine* engine_;
   LoadBalancer* balancer_;
   std::vector<GrpcChannel*> channels_;


### PR DESCRIPTION
The data race condition will corrupt the memory and crash the process.

Signed-off-by: Tao He <sighingnow@gmail.com>