### PR TITLE
Enables tensorflow 2 compatibility.

### DIFF
--- a/graphlearn/examples/tf/bipartite_sage/bipartite_sage.py
+++ b/graphlearn/examples/tf/bipartite_sage/bipartite_sage.py
@@ -14,7 +14,12 @@
 # =============================================================================
 '''SubGraph based BipartiteGraphSAGE.'''
 
-import tensorflow as tf
+try:
+  # https://www.tensorflow.org/guide/migrate
+  import tensorflow.compat.v1 as tf
+  tf.disable_v2_behavior()
+except ImportError:
+  import tensorflow as tf
 
 from graphlearn.python.nn.tf.config import conf
 from graphlearn.python.nn.tf.module import Module

--- a/graphlearn/examples/tf/bipartite_sage/train.py
+++ b/graphlearn/examples/tf/bipartite_sage/train.py
@@ -17,8 +17,14 @@ from __future__ import print_function
 import datetime
 
 import numpy as np
+try:
+  # https://www.tensorflow.org/guide/migrate
+  import tensorflow.compat.v1 as tf
+  tf.disable_v2_behavior()
+except ImportError:
+  import tensorflow as tf
+
 import graphlearn as gl
-import tensorflow as tf
 import graphlearn.python.nn.tf as tfg
 
 from bipartite_sage import BipartiteGraphSAGE

--- a/graphlearn/examples/tf/ego_bipartite_sage/ego_bipartite_sage.py
+++ b/graphlearn/examples/tf/ego_bipartite_sage/ego_bipartite_sage.py
@@ -16,7 +16,13 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import tensorflow as tf
+try:
+  # https://www.tensorflow.org/guide/migrate
+  import tensorflow.compat.v1 as tf
+  tf.disable_v2_behavior()
+except ImportError:
+  import tensorflow as tf
+
 import graphlearn.python.nn.tf as tfg
 
 

--- a/graphlearn/examples/tf/ego_bipartite_sage/train.py
+++ b/graphlearn/examples/tf/ego_bipartite_sage/train.py
@@ -21,7 +21,14 @@ import datetime
 from xmlrpc.client import Boolean
 import numpy as np
 import os, sys
-import tensorflow as tf
+
+try:
+  # https://www.tensorflow.org/guide/migrate
+  import tensorflow.compat.v1 as tf
+  tf.disable_v2_behavior()
+except ImportError:
+  import tensorflow as tf
+
 import graphlearn as gl
 import graphlearn.python.nn.tf as tfg
 

--- a/graphlearn/examples/tf/ego_gat/ego_gat.py
+++ b/graphlearn/examples/tf/ego_gat/ego_gat.py
@@ -16,7 +16,13 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import tensorflow as tf
+try:
+  # https://www.tensorflow.org/guide/migrate
+  import tensorflow.compat.v1 as tf
+  tf.disable_v2_behavior()
+except ImportError:
+  import tensorflow as tf
+
 import graphlearn.python.nn.tf as tfg
 
 

--- a/graphlearn/examples/tf/ego_gat/train_supervised.py
+++ b/graphlearn/examples/tf/ego_gat/train_supervised.py
@@ -16,11 +16,18 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import os, sys
 import argparse
 import datetime
+import os
+import sys
+
 import numpy as np
-import tensorflow as tf
+try:
+  # https://www.tensorflow.org/guide/migrate
+  import tensorflow.compat.v1 as tf
+  tf.disable_v2_behavior()
+except ImportError:
+  import tensorflow as tf
 
 import graphlearn as gl
 import graphlearn.python.nn.tf as tfg

--- a/graphlearn/examples/tf/ego_rgcn/ego_rgcn.py
+++ b/graphlearn/examples/tf/ego_rgcn/ego_rgcn.py
@@ -16,7 +16,13 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import tensorflow as tf
+try:
+  # https://www.tensorflow.org/guide/migrate
+  import tensorflow.compat.v1 as tf
+  tf.disable_v2_behavior()
+except ImportError:
+  import tensorflow as tf
+
 import graphlearn.python.nn.tf as tfg
 
 

--- a/graphlearn/examples/tf/ego_rgcn/train_supervised.py
+++ b/graphlearn/examples/tf/ego_rgcn/train_supervised.py
@@ -23,7 +23,13 @@ import os
 import sys
 
 import numpy as np
-import tensorflow as tf
+try:
+  # https://www.tensorflow.org/guide/migrate
+  import tensorflow.compat.v1 as tf
+  tf.disable_v2_behavior()
+except ImportError:
+  import tensorflow as tf
+
 import graphlearn as gl
 import graphlearn.python.nn.tf as tfg
 

--- a/graphlearn/examples/tf/ego_sage/ego_sage.py
+++ b/graphlearn/examples/tf/ego_sage/ego_sage.py
@@ -16,7 +16,13 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import tensorflow as tf
+try:
+  # https://www.tensorflow.org/guide/migrate
+  import tensorflow.compat.v1 as tf
+  tf.disable_v2_behavior()
+except ImportError:
+  import tensorflow as tf
+
 import graphlearn.python.nn.tf as tfg
 
 

--- a/graphlearn/examples/tf/ego_sage/k8s/dist_train.py
+++ b/graphlearn/examples/tf/ego_sage/k8s/dist_train.py
@@ -20,8 +20,15 @@ import sys
 import time
 
 import numpy as np
+
+try:
+  # https://www.tensorflow.org/guide/migrate
+  import tensorflow.compat.v1 as tf
+  tf.disable_v2_behavior()
+except ImportError:
+  import tensorflow as tf
+
 import graphlearn as gl
-import tensorflow as tf
 import graphlearn.python.nn.tf as tfg
 
 sys.path.append("..")

--- a/graphlearn/examples/tf/ego_sage/k8s/dist_trainer.py
+++ b/graphlearn/examples/tf/ego_sage/k8s/dist_trainer.py
@@ -23,10 +23,16 @@ import os
 import sys
 import time
 
+import numpy as np
+try:
+  # https://www.tensorflow.org/guide/migrate
+  import tensorflow.compat.v1 as tf
+  tf.disable_v2_behavior()
+except ImportError:
+  import tensorflow as tf
+
 import graphlearn as gl
 import graphlearn.python.nn.tf as tfg
-import numpy as np
-import tensorflow as tf
 
 sys.path.append("../..")
 from trainer import DistTrainer as BaseDistTrainer

--- a/graphlearn/examples/tf/ego_sage/train_supervised.py
+++ b/graphlearn/examples/tf/ego_sage/train_supervised.py
@@ -22,7 +22,13 @@ import os
 import sys
 
 import numpy as np
-import tensorflow as tf
+try:
+  # https://www.tensorflow.org/guide/migrate
+  import tensorflow.compat.v1 as tf
+  tf.disable_v2_behavior()
+except ImportError:
+  import tensorflow as tf
+
 import graphlearn as gl
 import graphlearn.python.nn.tf as tfg
 

--- a/graphlearn/examples/tf/ego_sage/train_unsupervised.py
+++ b/graphlearn/examples/tf/ego_sage/train_unsupervised.py
@@ -17,8 +17,14 @@ from __future__ import print_function
 import datetime
 
 import numpy as np
+try:
+  # https://www.tensorflow.org/guide/migrate
+  import tensorflow.compat.v1 as tf
+  tf.disable_v2_behavior()
+except ImportError:
+  import tensorflow as tf
+
 import graphlearn as gl
-import tensorflow as tf
 import graphlearn.python.nn.tf as tfg
 
 from ego_sage import EgoGraphSAGE

--- a/graphlearn/examples/tf/sage/train.py
+++ b/graphlearn/examples/tf/sage/train.py
@@ -17,8 +17,14 @@ from __future__ import print_function
 import datetime
 
 import numpy as np
+try:
+  # https://www.tensorflow.org/guide/migrate
+  import tensorflow.compat.v1 as tf
+  tf.disable_v2_behavior()
+except ImportError:
+  import tensorflow as tf
+
 import graphlearn as gl
-import tensorflow as tf
 import graphlearn.python.nn.tf as tfg
 
 from edge_inducer import EdgeInducer

--- a/graphlearn/examples/tf/seal/seal_link_predict.py
+++ b/graphlearn/examples/tf/seal/seal_link_predict.py
@@ -17,9 +17,14 @@ from __future__ import print_function
 import datetime
 
 import numpy as np
-import graphlearn as gl
-import tensorflow as tf
+try:
+  # https://www.tensorflow.org/guide/migrate
+  import tensorflow.compat.v1 as tf
+  tf.disable_v2_behavior()
+except ImportError:
+  import tensorflow as tf
 
+import graphlearn as gl
 import graphlearn.python.nn.tf as tfg
 
 from edge_cn_inducer import EdgeCNInducer

--- a/graphlearn/examples/tf/trainer.py
+++ b/graphlearn/examples/tf/trainer.py
@@ -23,10 +23,16 @@ import datetime
 import os
 import time
 
+import numpy as np
 import graphlearn as gl
 import graphlearn.python.nn.tf as tfg
-import numpy as np
-import tensorflow as tf
+
+try:
+  # https://www.tensorflow.org/guide/migrate
+  import tensorflow.compat.v1 as tf
+  tf.disable_v2_behavior()
+except ImportError:
+  import tensorflow as tf
 
 from tensorflow.python.client import timeline
 run_options = tf.RunOptions(trace_level=tf.RunOptions.FULL_TRACE)

--- a/graphlearn/examples/tf/ultra_gcn/train.py
+++ b/graphlearn/examples/tf/ultra_gcn/train.py
@@ -16,7 +16,13 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import tensorflow as tf
+try:
+  # https://www.tensorflow.org/guide/migrate
+  import tensorflow.compat.v1 as tf
+  tf.disable_v2_behavior()
+except ImportError:
+  import tensorflow as tf
+
 import graphlearn as gl
 
 from ultra_gcn import UltraGCN

--- a/graphlearn/examples/tf/ultra_gcn/ultra_gcn.py
+++ b/graphlearn/examples/tf/ultra_gcn/ultra_gcn.py
@@ -16,7 +16,13 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import tensorflow as tf
+try:
+  # https://www.tensorflow.org/guide/migrate
+  import tensorflow.compat.v1 as tf
+  tf.disable_v2_behavior()
+except ImportError:
+  import tensorflow as tf
+
 import graphlearn as gl
 
 EMB_PT_SIZE = 128 * 1024

--- a/graphlearn/python/nn/tf/data/batchgraph.py
+++ b/graphlearn/python/nn/tf/data/batchgraph.py
@@ -18,7 +18,12 @@ from __future__ import division
 from __future__ import print_function
 
 import numpy as np
-import tensorflow as tf
+try:
+  # https://www.tensorflow.org/guide/migrate
+  import tensorflow.compat.v1 as tf
+  tf.disable_v2_behavior()
+except ImportError:
+  import tensorflow as tf
 
 from graphlearn.python.nn.data import Data
 from graphlearn.python.nn.subgraph import SubGraph

--- a/graphlearn/python/nn/tf/data/dataset.py
+++ b/graphlearn/python/nn/tf/data/dataset.py
@@ -17,7 +17,12 @@ from __future__ import division
 from __future__ import print_function
 
 import numpy as np
-import tensorflow as tf
+try:
+  # https://www.tensorflow.org/guide/migrate
+  import tensorflow.compat.v1 as tf
+  tf.disable_v2_behavior()
+except ImportError:
+  import tensorflow as tf
 
 from graphlearn import pywrap_graphlearn as pywrap
 from graphlearn.python.errors import OutOfRangeError

--- a/graphlearn/python/nn/tf/data/feature_column.py
+++ b/graphlearn/python/nn/tf/data/feature_column.py
@@ -20,7 +20,12 @@ import json
 import os
 
 import numpy as np
-import tensorflow as tf
+try:
+  # https://www.tensorflow.org/guide/migrate
+  import tensorflow.compat.v1 as tf
+  tf.disable_v2_behavior()
+except ImportError:
+  import tensorflow as tf
 
 from graphlearn.python.nn.tf.config import conf
 from graphlearn.python.nn.tf.module import Module

--- a/graphlearn/python/nn/tf/data/feature_handler.py
+++ b/graphlearn/python/nn/tf/data/feature_handler.py
@@ -18,7 +18,12 @@ from __future__ import print_function
 
 """Classes for Feature encoding using FeatureColumn."""
 
-import tensorflow as tf
+try:
+  # https://www.tensorflow.org/guide/migrate
+  import tensorflow.compat.v1 as tf
+  tf.disable_v2_behavior()
+except ImportError:
+  import tensorflow as tf
 
 from graphlearn.python.data.feature_spec import *
 from graphlearn.python.nn.tf.data.feature_column import *

--- a/graphlearn/python/nn/tf/data/hetero_batchgraph.py
+++ b/graphlearn/python/nn/tf/data/hetero_batchgraph.py
@@ -18,7 +18,12 @@ from __future__ import division
 from __future__ import print_function
 
 import numpy as np
-import tensorflow as tf
+try:
+  # https://www.tensorflow.org/guide/migrate
+  import tensorflow.compat.v1 as tf
+  tf.disable_v2_behavior()
+except ImportError:
+  import tensorflow as tf
 
 from graphlearn.python.nn.data import Data
 from graphlearn.python.nn.hetero_subgraph import HeteroSubGraph

--- a/graphlearn/python/nn/tf/data/test/test_feature_column.py
+++ b/graphlearn/python/nn/tf/data/test/test_feature_column.py
@@ -17,8 +17,15 @@ from __future__ import division
 from __future__ import print_function
 
 import unittest
+
 import numpy as np
-import tensorflow as tf
+try:
+  # https://www.tensorflow.org/guide/migrate
+  import tensorflow.compat.v1 as tf
+  tf.disable_v2_behavior()
+except ImportError:
+  import tensorflow as tf
+
 from graphlearn.python.nn.tf.config import conf
 from graphlearn.python.nn.tf.data.feature_column import *
 

--- a/graphlearn/python/nn/tf/data/test/test_feature_handler.py
+++ b/graphlearn/python/nn/tf/data/test/test_feature_handler.py
@@ -18,8 +18,15 @@ from __future__ import print_function
 
 import unittest
 import random
+
 import numpy as np
-import tensorflow as tf
+try:
+  # https://www.tensorflow.org/guide/migrate
+  import tensorflow.compat.v1 as tf
+  tf.disable_v2_behavior()
+except ImportError:
+  import tensorflow as tf
+
 from graphlearn.python.data.feature_spec import *
 from graphlearn.python.nn.data import Data
 from graphlearn.python.nn.tf.data.feature_column import *

--- a/graphlearn/python/nn/tf/layers/ego_gat_conv.py
+++ b/graphlearn/python/nn/tf/layers/ego_gat_conv.py
@@ -19,7 +19,12 @@ from __future__ import division
 from __future__ import print_function
 
 import numpy as np
-import tensorflow as tf
+try:
+  # https://www.tensorflow.org/guide/migrate
+  import tensorflow.compat.v1 as tf
+  tf.disable_v2_behavior()
+except ImportError:
+  import tensorflow as tf
 
 from graphlearn.python.nn.tf.config import conf
 from graphlearn.python.nn.tf.layers.ego_layer import EgoConv, EgoLayer

--- a/graphlearn/python/nn/tf/layers/ego_gin_conv.py
+++ b/graphlearn/python/nn/tf/layers/ego_gin_conv.py
@@ -19,7 +19,12 @@ from __future__ import division
 from __future__ import print_function
 
 import numpy as np
-import tensorflow as tf
+try:
+  # https://www.tensorflow.org/guide/migrate
+  import tensorflow.compat.v1 as tf
+  tf.disable_v2_behavior()
+except ImportError:
+  import tensorflow as tf
 
 from graphlearn.python.nn.tf.layers.ego_layer import EgoConv, EgoLayer
 from graphlearn.python.nn.tf.layers.linear_layer import LinearLayer

--- a/graphlearn/python/nn/tf/layers/ego_rgcn_conv.py
+++ b/graphlearn/python/nn/tf/layers/ego_rgcn_conv.py
@@ -19,7 +19,12 @@ from __future__ import division
 from __future__ import print_function
 
 import numpy as np
-import tensorflow as tf
+try:
+  # https://www.tensorflow.org/guide/migrate
+  import tensorflow.compat.v1 as tf
+  tf.disable_v2_behavior()
+except ImportError:
+  import tensorflow as tf
 
 from graphlearn.python.nn.tf.layers.ego_layer import EgoConv, EgoLayer
 from graphlearn.python.nn.tf.layers.linear_layer import LinearLayer

--- a/graphlearn/python/nn/tf/layers/ego_sage_conv.py
+++ b/graphlearn/python/nn/tf/layers/ego_sage_conv.py
@@ -19,7 +19,12 @@ from __future__ import division
 from __future__ import print_function
 
 import numpy as np
-import tensorflow as tf
+try:
+  # https://www.tensorflow.org/guide/migrate
+  import tensorflow.compat.v1 as tf
+  tf.disable_v2_behavior()
+except ImportError:
+  import tensorflow as tf
 
 from graphlearn.python.nn.tf.layers.ego_layer import EgoConv, EgoLayer
 from graphlearn.python.nn.tf.layers.linear_layer import LinearLayer

--- a/graphlearn/python/nn/tf/layers/gat_conv.py
+++ b/graphlearn/python/nn/tf/layers/gat_conv.py
@@ -14,7 +14,12 @@
 # =============================================================================
 """SubGraph based GAT convolutional layer"""
 
-import tensorflow as tf
+try:
+  # https://www.tensorflow.org/guide/migrate
+  import tensorflow.compat.v1 as tf
+  tf.disable_v2_behavior()
+except ImportError:
+  import tensorflow as tf
 
 from graphlearn.python.nn.tf.config import conf
 from graphlearn.python.nn.tf.layers.sub_conv import SubConv

--- a/graphlearn/python/nn/tf/layers/gcn_conv.py
+++ b/graphlearn/python/nn/tf/layers/gcn_conv.py
@@ -14,7 +14,12 @@
 # =============================================================================
 """SubGraph based GCN convolutional layer"""
 
-import tensorflow as tf
+try:
+  # https://www.tensorflow.org/guide/migrate
+  import tensorflow.compat.v1 as tf
+  tf.disable_v2_behavior()
+except ImportError:
+  import tensorflow as tf
 
 from graphlearn.python.nn.tf.layers.sub_conv import SubConv
 

--- a/graphlearn/python/nn/tf/layers/hetero_conv.py
+++ b/graphlearn/python/nn/tf/layers/hetero_conv.py
@@ -18,9 +18,14 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import tensorflow as tf
-
 from collections import defaultdict
+
+try:
+  # https://www.tensorflow.org/guide/migrate
+  import tensorflow.compat.v1 as tf
+  tf.disable_v2_behavior()
+except ImportError:
+  import tensorflow as tf
 
 from graphlearn.python.nn.tf.module import Module
 

--- a/graphlearn/python/nn/tf/layers/linear_layer.py
+++ b/graphlearn/python/nn/tf/layers/linear_layer.py
@@ -16,7 +16,13 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import tensorflow as tf
+try:
+  # https://www.tensorflow.org/guide/migrate
+  import tensorflow.compat.v1 as tf
+  tf.disable_v2_behavior()
+except ImportError:
+  import tensorflow as tf
+
 from graphlearn.python.nn.tf.module import Module
 
 

--- a/graphlearn/python/nn/tf/layers/sage_conv.py
+++ b/graphlearn/python/nn/tf/layers/sage_conv.py
@@ -14,7 +14,12 @@
 # =============================================================================
 """SubGraph based GraphSAGE convolutional layer"""
 
-import tensorflow as tf
+try:
+  # https://www.tensorflow.org/guide/migrate
+  import tensorflow.compat.v1 as tf
+  tf.disable_v2_behavior()
+except ImportError:
+  import tensorflow as tf
 
 from graphlearn.python.nn.tf.layers.sub_conv import SubConv
 

--- a/graphlearn/python/nn/tf/layers/test/test_ego_rgcn_conv.py
+++ b/graphlearn/python/nn/tf/layers/test/test_ego_rgcn_conv.py
@@ -17,8 +17,15 @@ from __future__ import division
 from __future__ import print_function
 
 import unittest
+
 import numpy as np
-import tensorflow as tf
+try:
+  # https://www.tensorflow.org/guide/migrate
+  import tensorflow.compat.v1 as tf
+  tf.disable_v2_behavior()
+except ImportError:
+  import tensorflow as tf
+
 from graphlearn.python.nn.tf.layers.ego_rgcn_conv import EgoRGCNConv
 
 

--- a/graphlearn/python/nn/tf/loss.py
+++ b/graphlearn/python/nn/tf/loss.py
@@ -17,7 +17,12 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import tensorflow as tf
+try:
+  # https://www.tensorflow.org/guide/migrate
+  import tensorflow.compat.v1 as tf
+  tf.disable_v2_behavior()
+except ImportError:
+  import tensorflow as tf
 
 # Unsupervised loss.
 def sigmoid_cross_entropy_loss(pos_logit,

--- a/graphlearn/python/nn/tf/model/ego_gnn.py
+++ b/graphlearn/python/nn/tf/model/ego_gnn.py
@@ -18,7 +18,13 @@ from __future__ import print_function
 
 """EgoGraph based GNN model."""
 
-import tensorflow as tf
+try:
+  # https://www.tensorflow.org/guide/migrate
+  import tensorflow.compat.v1 as tf
+  tf.disable_v2_behavior()
+except ImportError:
+  import tensorflow as tf
+
 from graphlearn.python.nn.tf.config import conf
 from graphlearn.python.nn.tf.module import Module
 

--- a/graphlearn/python/nn/tf/model/gat.py
+++ b/graphlearn/python/nn/tf/model/gat.py
@@ -14,7 +14,12 @@
 # =============================================================================
 '''SubGraph based GAT.'''
 
-import tensorflow as tf
+try:
+  # https://www.tensorflow.org/guide/migrate
+  import tensorflow.compat.v1 as tf
+  tf.disable_v2_behavior()
+except ImportError:
+  import tensorflow as tf
 
 from graphlearn.python.nn.tf.config import conf
 from graphlearn.python.nn.tf.module import Module

--- a/graphlearn/python/nn/tf/model/gcn.py
+++ b/graphlearn/python/nn/tf/model/gcn.py
@@ -14,7 +14,12 @@
 # =============================================================================
 '''SubGraph based GCN.'''
 
-import tensorflow as tf
+try:
+  # https://www.tensorflow.org/guide/migrate
+  import tensorflow.compat.v1 as tf
+  tf.disable_v2_behavior()
+except ImportError:
+  import tensorflow as tf
 
 from graphlearn.python.nn.tf.config import conf
 from graphlearn.python.nn.tf.module import Module

--- a/graphlearn/python/nn/tf/model/link_predictor.py
+++ b/graphlearn/python/nn/tf/model/link_predictor.py
@@ -16,7 +16,13 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import tensorflow as tf
+try:
+  # https://www.tensorflow.org/guide/migrate
+  import tensorflow.compat.v1 as tf
+  tf.disable_v2_behavior()
+except ImportError:
+  import tensorflow as tf
+
 from graphlearn.python.nn.tf.config import conf
 from graphlearn.python.nn.tf.module import Module
 from graphlearn.python.nn.tf.layers.linear_layer import LinearLayer

--- a/graphlearn/python/nn/tf/model/sage.py
+++ b/graphlearn/python/nn/tf/model/sage.py
@@ -14,7 +14,12 @@
 # =============================================================================
 '''SubGraph based GraphSAGE.'''
 
-import tensorflow as tf
+try:
+  # https://www.tensorflow.org/guide/migrate
+  import tensorflow.compat.v1 as tf
+  tf.disable_v2_behavior()
+except ImportError:
+  import tensorflow as tf
 
 from graphlearn.python.nn.tf.config import conf
 from graphlearn.python.nn.tf.module import Module

--- a/graphlearn/python/nn/tf/model/seal.py
+++ b/graphlearn/python/nn/tf/model/seal.py
@@ -14,7 +14,12 @@
 # =============================================================================
 '''SubGraph based SEAL.'''
 
-import tensorflow as tf
+try:
+  # https://www.tensorflow.org/guide/migrate
+  import tensorflow.compat.v1 as tf
+  tf.disable_v2_behavior()
+except ImportError:
+  import tensorflow as tf
 
 from graphlearn.python.nn.tf.config import conf
 from graphlearn.python.nn.tf.module import Module

--- a/graphlearn/python/nn/tf/utils/softmax.py
+++ b/graphlearn/python/nn/tf/utils/softmax.py
@@ -14,7 +14,12 @@
 # =============================================================================
 """unsorted_segment_softmax op"""
 
-import tensorflow as tf
+try:
+  # https://www.tensorflow.org/guide/migrate
+  import tensorflow.compat.v1 as tf
+  tf.disable_v2_behavior()
+except ImportError:
+  import tensorflow as tf
 
 def unsorted_segment_softmax(data, segment_ids, num_segments):
   """Computes segment_softmax.

--- a/graphlearn/python/nn/tf/utils/sync_barrier.py
+++ b/graphlearn/python/nn/tf/utils/sync_barrier.py
@@ -16,7 +16,13 @@
 
 import logging
 import time
-import tensorflow as tf
+
+try:
+  # https://www.tensorflow.org/guide/migrate
+  import tensorflow.compat.v1 as tf
+  tf.disable_v2_behavior()
+except ImportError:
+  import tensorflow as tf
 
 
 class SyncBarrierHook(tf.train.SessionRunHook):


### PR DESCRIPTION
Translate `import tensorflow` to

```python
try:
  # https://www.tensorflow.org/guide/migrate
  import tensorflow.compat.v1 as tf
  tf.disable_v2_behavior()
except ImportError:
  import tensorflow as tf
```