### PR TITLE
GraphScope on 3/3 part 2: pick up the previous graphscope functions

### DIFF
--- a/graphlearn/.gitignore
+++ b/graphlearn/.gitignore
@@ -8,5 +8,5 @@ examples/tf/*.tar.gz
 # core dump
 /core
 
-# ignore generated __init__.py
-/__init__.py
+# ignore generated version.py
+/python/version.py

--- a/graphlearn/CMakeLists.txt
+++ b/graphlearn/CMakeLists.txt
@@ -543,9 +543,9 @@ add_custom_command (TARGET python
   COMMAND ${CMAKE_COMMAND} -E remove_directory graphlearn.egg-info
   COMMAND ${CMAKE_COMMAND} -E make_directory ${GL_PYTHON_LIB_DIR}
   COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:graphlearn_shared> ${GL_PYTHON_LIB_DIR}
-  COMMAND cp -f ${GL_SETUP_DIR}/gl.__init__.py ${GL_PYTHON_DIR}/__init__.py
-  COMMAND echo "__version__ = ${VERSION}" >> ${GL_PYTHON_DIR}/__init__.py
-  COMMAND echo "__git_version__ = '${GIT_BRANCH}-${GIT_VERSION}'" >> ${GL_PYTHON_DIR}/__init__.py
+  COMMAND cp -f ${GL_SETUP_DIR}/version.py ${GL_PYTHON_DIR}/python/version.py
+  COMMAND echo "__version__ = ${VERSION}" >> ${GL_PYTHON_DIR}/python/version.py
+  COMMAND echo "__git_version__ = '${GIT_BRANCH}-${GIT_VERSION}'" >> ${GL_PYTHON_DIR}/python/version.py
   COMMAND OPEN_KNN=${KNN_FLAG} ${GL_PYTHON_BIN} ${GL_SETUP_DIR}/setup.py build_ext --inplace
   COMMAND OPEN_KNN=${KNN_FLAG} ${GL_PYTHON_BIN} ${GL_SETUP_DIR}/setup.py bdist_wheel
   COMMAND ${CMAKE_COMMAND} -E make_directory "${GL_BUILT_BIN_DIR}/ge_data/data"
@@ -553,7 +553,7 @@ add_custom_command (TARGET python
   WORKING_DIRECTORY ${GL_ROOT}
   VERBATIM)
 
-# install the graphlearn_shared library
+# install the graphlearn_shared library.
 install(TARGETS graphlearn_shared
         EXPORT graphlearn-targets
         ARCHIVE DESTINATION lib

--- a/graphlearn/CMakeLists.txt
+++ b/graphlearn/CMakeLists.txt
@@ -292,7 +292,7 @@ endif ()
 
 ## contrib vineyard
 if (WITH_VINEYARD)
-  message(INFO "Graph-learn is built with vineyard support.")
+  message("Graph-learn is built with vineyard support.")
   find_package (vineyard)
   include_directories (SYSTEM ${VINEYARD_INCLUDE_DIRS})
   add_definitions (-DWITH_VINEYARD)

--- a/graphlearn/__init__.py
+++ b/graphlearn/__init__.py
@@ -13,6 +13,11 @@
 # limitations under the License.
 # =============================================================================
 
+try:
+    from .python.version import __version__, __git_version__
+except ImportError:
+    pass
+
 from graphlearn import pywrap_graphlearn as pywrap
 from graphlearn.pywrap_graphlearn import IndexOption
 

--- a/graphlearn/examples/__init__.py
+++ b/graphlearn/examples/__init__.py
@@ -39,13 +39,14 @@ try:
         from .tf.ego_bipartite_sage.ego_bipartite_sage import EgoBipartiteGraphSAGE
         from .tf.ego_gat.ego_gat import EgoGAT
         from .tf.ego_rgcn.ego_rgcn import EgoRGCN
-        from .tf.ego_rgcn.ego_rgcn_data import EgoRGCNDataLoader
+        from .tf.ego_rgcn.ego_rgcn_data_loader import EgoRGCNDataLoader
         from .tf.ego_sage.ego_sage import EgoGraphSAGE
-        from .tf.ego_sage.ego_sage_data import EgoSAGESupervisedDataLoader, EgoSAGEUnsupervisedDataLoader
+        from .tf.ego_sage.ego_sage_data_loader import EgoSAGESupervisedDataLoader, \
+            EgoSAGEUnsupervisedDataLoader
         from .tf.sage.edge_inducer import EdgeInducer
         from .tf.seal.edge_cn_inducer import EdgeCNInducer
         from .tf.ultra_gcn.ultra_gcn import UltraGCN
-    except:
+    except:  # noqa: E722, pylint: disable=bare-except
         pass
 
 finally:

--- a/graphlearn/examples/tf/ego_rgcn/__init__.py
+++ b/graphlearn/examples/tf/ego_rgcn/__init__.py
@@ -14,4 +14,4 @@
 # =============================================================================
 
 from .ego_rgcn import EgoRGCN
-from .ego_rgcn_data import EgoRGCNData
+from .ego_rgcn_data_loader import EgoRGCNDataLoader

--- a/graphlearn/examples/tf/ego_sage/__init__.py
+++ b/graphlearn/examples/tf/ego_sage/__init__.py
@@ -14,3 +14,4 @@
 # =============================================================================
 
 from .ego_sage import EgoGraphSAGE
+from .ego_sage_data_loader import EgoSAGESupervisedDataLoader, EgoSAGEUnsupervisedDataLoader

--- a/graphlearn/examples/tf/trainer.py
+++ b/graphlearn/examples/tf/trainer.py
@@ -137,6 +137,7 @@ class TFTrainer(object):
           train_loss = outs[1]
           global_step = outs[-1]
           # Print results
+          local_step += 1
           if local_step % self.progress_steps == 0:
             if self.is_local:
               print(datetime.datetime.now(),
@@ -155,7 +156,6 @@ class TFTrainer(object):
             t = time.time()
             last_local_step = local_step
             last_global_step = global_step
-          local_step += 1
 
       if self.sync_barrier is not None:
         self.sync_barrier.end(self.sess)
@@ -179,6 +179,7 @@ class TFTrainer(object):
           if outs is not None:
             accuracy = outs[0]
             global_step = outs[-1]
+            local_step += 1
             # Print results
             if local_step % self.progress_steps == 0:
               if self.is_local:
@@ -198,7 +199,6 @@ class TFTrainer(object):
               t = time.time()
               last_local_step = local_step
               last_global_step = global_step
-            local_step += 1
           total_test_acc.append(accuracy)
       except tf.errors.OutOfRangeError:
         print("Finished.")
@@ -224,9 +224,9 @@ class TFTrainer(object):
           # [B,], [B,dim]
           feat = [','.join(str(x) for x in arr) for arr in outs[1]]
           emb_writer.write(list(zip(outs[0], feat)), indices=[0, 1])  # id,emb
+          local_step += 1
           if local_step % self.progress_steps == 0:
             print('Saved {} node embeddings, Time(s) {:.4f}'.format(local_step * batch_size, time.time() - t))
-          local_step += 1
         except tf.errors.OutOfRangeError:
           print('Save node embeddings done.')
           break

--- a/graphlearn/python/c/py_client.cc
+++ b/graphlearn/python/c/py_client.cc
@@ -103,12 +103,12 @@ void init_client_module(py::module& m) {
          py::arg("request"),
          py::arg("response"))
     .def("run_dag",
-         [](Client & self, DagDef* dag_def) {
+         [](Client & self, DagDef* dag_def, const bool copy) {
            std::unique_ptr<DagRequest> req(new DagRequest());
-           req->ParseFrom(dag_def);
+           req->ParseFrom(dag_def, copy);
            return self.RunDag(req.get());
          },
-         py::arg("dag_def"))
+         py::arg("dag_def"), py::arg("copy") = false)
     .def("get_dag_values",
          CALL_FUNC(GetDagValues),
          py::arg("request"),

--- a/graphlearn/python/c/py_export.cc
+++ b/graphlearn/python/c/py_export.cc
@@ -248,7 +248,6 @@ PYBIND11_MODULE(pywrap_graphlearn, m) {
         &NewRpcClient,
         py::return_value_policy::take_ownership,
         py::arg("server_id") = -1,
-        py::arg("server_own") = false,
         py::arg("client_own") = true);
 
   init_client_module(m);

--- a/graphlearn/python/client.py
+++ b/graphlearn/python/client.py
@@ -38,48 +38,52 @@ class Client(object):
     self._client_id = client_id
     self._in_memory = in_memory
     self._client_cache = []
+    self._client_own = kwargs.get("client_own", True)
     if in_memory:
+      self._own_servers = None
       self._client_cache.append(pywrap.in_memory_client())
-      self._cur_index = 0
+      self._current_index = 0
     else:
       server_id = kwargs.get("server_id", -1)
-      client_own = kwargs.get("client_own", True)
       # auto select
-      client = pywrap.rpc_client(server_id, client_own)
+      client = pywrap.rpc_client(server_id, self._client_own)
       self._own_servers = client.get_own_servers()
       self._client_cache = [None] * len(self._own_servers)
-      self._client_cache[0] = client
-      self._cur_index = 0
+      self._client_cache[0] = pywrap.rpc_client(self._own_servers[0], self._client_own)
+      self._current_index = 0
 
-  @property
-  def own_servers(self):
-    return self._own_servers
+  def __len__(self):
+    """ The capacity of the clients inside the client wrapper.
+    """
+    return len(self._client_cache)
 
   def is_in_memory(self):
     return self._in_memory
 
   @property
   def current_client(self):
-    return self._client_cache[self._cur_index]
+    return self._client_cache[self._current_index]
 
   def connect_to_next_server(self):
     if self._in_memory:
       return False
 
-    next_index = (self._cur_index + 1) % len(self._own_servers)
-    if next_index == self._cur_index:
-      return False   # the client has only one own server
-    elif next_index < self._cur_index:
+    if len(self._client_cache) == 1:  # the client has only one own server
+      return False
+
+    # move to the next server
+    next_index = (self._current_index + 1) % len(self._own_servers)
+    if next_index < self._current_index:
       # one epoch finish, start next epoch
-      self._cur_index = next_index
+      self._current_index = next_index
       return False
     else:
       # one server finish, start to connect next server
       if self._client_cache[next_index] is None:
         self._client_cache[next_index] = pywrap.rpc_client(
-          self._own_servers[next_index], True, True
+          self._own_servers[next_index], self._client_own
         )
-      self._cur_index = next_index
+      self._current_index = next_index
       return True
 
   def stop(self):
@@ -118,8 +122,8 @@ class Client(object):
   def run_op(self, request, response):
     return self.current_client.run_op(request, response)
 
-  def run_dag(self, dag_def):
-    return self.current_client.run_dag(dag_def)
+  def run_dag(self, dag_def, copy=False):
+    return self.current_client.run_dag(dag_def, copy)
 
   def get_dag_values(self, request, response):
     return self.current_client.get_dag_values(request, response)

--- a/graphlearn/python/client.py
+++ b/graphlearn/python/client.py
@@ -1,0 +1,129 @@
+# Copyright 2020-2022 Alibaba Group Holding Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# =============================================================================
+""" GraphLearn Client.
+"""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+from graphlearn import pywrap_graphlearn as pywrap
+
+
+class Client(object):
+  """ A :code:`Client` class manages a set of remote server to connect
+      and do a round-robin sample between those GraphLearn clients.
+  """
+
+  def __init__(self,
+               client_id = 0,
+               in_memory = True,
+               **kwargs):  # pylint: disable=unused-argument
+    """ Create GraphLearn server instance with given cluster env info.
+    Args:
+      client_id: An int, client index, starts from 0.
+      in_memory: An bool, is in memory client or rpc client.
+    """
+    self._client_id = client_id
+    self._in_memory = in_memory
+    self._client_cache = []
+    if in_memory:
+      self._client_cache.append(pywrap.in_memory_client())
+      self._cur_index = 0
+    else:
+      server_id = kwargs.get("server_id", -1)
+      server_own = kwargs.get("server_own", False)
+      client_own = kwargs.get("client_own", True)
+      # auto select
+      client = pywrap.rpc_client(server_id, server_own, client_own)
+      self._own_servers = client.get_own_servers()
+      self._client_cache = [None] * len(self._own_servers)
+      self._client_cache[0] = client
+      self._cur_index = 0
+
+  @property
+  def own_servers(self):
+    return self._own_servers
+
+  def is_in_memory(self):
+    return self._in_memory
+
+  @property
+  def current_client(self):
+    return self._client_cache[self._cur_index]
+
+  def connect_to_next_server(self):
+    if self._in_memory:
+      return False
+
+    next_index = (self._cur_index + 1) % len(self._own_servers)
+    if next_index == self._cur_index:
+      return False   # the client has only one own server
+    elif next_index < self._cur_index:
+      # one epoch finish, start next epoch
+      self._cur_index = next_index
+      return False
+    else:
+      # one server finish, start to connect next server
+      if self._client_cache[next_index] is None:
+        self._client_cache[next_index] = pywrap.rpc_client(
+          self._own_servers[next_index], True, True
+        )
+      self._cur_index = next_index
+      return True
+
+  def stop(self):
+    for client in self._client_cache:
+      if client is not None:
+        client.stop()
+    self._client_cache.clear()
+
+  def get_nodes(self, request, response):
+    return self.current_client.get_nodes(request, response)
+
+  def get_edges(self, request, response):
+    return self.current_client.get_edges(request, response)
+
+  def lookup_nodes(self, request, response):
+    return self.current_client.lookup_nodes(request, response)
+
+  def lookup_edges(self, request, response):
+    return self.current_client.lookup_edges(request, response)
+
+  def sample_neighbor(self, request, response):
+    return self.current_client.sample_neighbor(request, response)
+
+  def agg_nodes(self, request, response):
+    return self.current_client.agg_nodes(request, response)
+
+  def sample_subgraph(self, request, response):
+    return self.current_client.sample_subgraph(request, response)
+
+  def get_stats(self, request, response):
+    return self.current_client.get_stats(request, response)
+
+  def get_degree(self, request, response):
+    return self.current_client.get_degree(request, response)
+
+  def run_op(self, request, response):
+    return self.current_client.run_op(request, response)
+
+  def run_dag(self, dag_def):
+    return self.current_client.run_dag(dag_def)
+
+  def get_dag_values(self, request, response):
+    return self.current_client.get_dag_values(request, response)
+
+  def cond_neg_sample(self, request, response):
+    return self.current_client.cond_neg_sample(request, response)

--- a/graphlearn/python/client.py
+++ b/graphlearn/python/client.py
@@ -43,10 +43,9 @@ class Client(object):
       self._cur_index = 0
     else:
       server_id = kwargs.get("server_id", -1)
-      server_own = kwargs.get("server_own", False)
       client_own = kwargs.get("client_own", True)
       # auto select
-      client = pywrap.rpc_client(server_id, server_own, client_own)
+      client = pywrap.rpc_client(server_id, client_own)
       self._own_servers = client.get_own_servers()
       self._client_cache = [None] * len(self._own_servers)
       self._client_cache[0] = client

--- a/graphlearn/python/graph.py
+++ b/graphlearn/python/graph.py
@@ -106,6 +106,7 @@ class Graph(object):
             "client_count": 1,
             "vineyard_socket": "/var/run/vineyard.sock",
             "vineyard_id": 13278328736,
+            "fragments": [13278328736, ...],  # fragment ids, may be None
             "node_schema": [
                 "user:false:false:10:0:0",
                 "item:true:false:0:0:5"
@@ -519,6 +520,9 @@ class Graph(object):
     cluster = {'server': self._vineyard_handle['server'],
                'client_count': self._vineyard_handle['client_count']}
     if server_index is not None:
+      # re-target to fragment id, if exists
+      if self._vineyard_handle.get('fragments', None):
+        pywrap.set_vineyard_graph_id(self._vineyard_handle['fragments'][server_index])
       self.init(cluster=cluster, task_index=server_index, job_name="server")
     else:
       self.init(cluster=cluster, task_index=worker_index, job_name="client")

--- a/graphlearn/python/graph.py
+++ b/graphlearn/python/graph.py
@@ -17,11 +17,15 @@ from __future__ import division
 from __future__ import print_function
 
 import atexit
+import base64
 import json
+import sys
 import warnings
+
 import numpy as np
 
 from graphlearn import pywrap_graphlearn as pywrap
+from graphlearn.python.client import Client
 from graphlearn.python.server import Server
 import graphlearn.python.data as data
 import graphlearn.python.errors as errors
@@ -81,10 +85,116 @@ class Graph(object):
 
     self._datasets = []
 
+    self._with_vineyard = False
+    self._vineyard_handle = None
+
     def stop_sampling():
       if self._server:
         self._server.stop_sampling()
     atexit.register(stop_sampling)
+
+  def vineyard(self, handle, nodes=None, edges=None):
+    """ Initialize a graph from vineyard.
+
+    :code:`handle` is the schema information of the vineyard graph, as shown in
+    the following example:
+
+    .. code:: python
+
+        {
+            "server": "127.0.0.1:8888,127.0.0.1:8889",
+            "client_count": 1,
+            "vineyard_socket": "/var/run/vineyard.sock",
+            "vineyard_id": 13278328736,
+            "node_schema": [
+                "user:false:false:10:0:0",
+                "item:true:false:0:0:5"
+            ],
+            "edge_schema": [
+                "user:click:item:true:false:0:0:0",
+                "user:buy:item:true:true:0:0:0",
+                "item:similar:item:false:false:10:0:0"
+            ],
+            "node_attribute_types": {
+                "person": {
+                    "age": "i",
+                    "name": "s",
+                },
+            },
+            "edge_attribute_types": {
+                "knows": {
+                    "weight": "f",
+                },
+            },
+        }
+
+    Fields in :code:`schema` are:
+
+      + the name of node type or edge type
+      + whether the graph is weighted graph
+      + whether the graph is labeled graph
+      + the number of int attributes
+      + the number of float attributes
+      + the number of string attributes
+    """
+    self._with_vineyard = True
+    if not isinstance(handle, dict):
+      handle = json.loads(base64.b64decode(handle).decode('utf-8'))
+    self._vineyard_handle = handle
+    pywrap.set_vineyard_graph_id(handle['vineyard_id'])
+    pywrap.set_vineyard_ipc_socket(handle['vineyard_socket'])
+
+    for node_info in handle['node_schema']:
+      confs = node_info.split(':')
+      if len(confs) != 6:
+        continue
+      node_type = confs[0]
+      if nodes is not None and node_type not in nodes:
+        continue
+      weighted = confs[1] == 'true'
+      labeled = confs[2] == 'true'
+      n_int = int(confs[3])
+      n_float = int(confs[4])
+      n_string = int(confs[5])
+      self.node(source='',
+                node_type=node_type,
+                decoder=self._make_vineyard_decoder(
+                  weighted, labeled, n_int, n_float, n_string))
+
+    for edge_info in handle['edge_schema']:
+      confs = edge_info.split(':')
+      if len(confs) != 8:
+        continue
+      src_node_type = confs[0]
+      edge_type = confs[1]
+      dst_node_type = confs[2]
+      if edges is not None and [src_node_type, edge_type, dst_node_type] not in edges \
+        and (src_node_type, edge_type, dst_node_type) not in edges:
+        continue
+      if 'reverse' not in edge_type:
+        self._undirected_edges.append(edge_type)
+      weighted = confs[3] == 'true'
+      labeled = confs[4] == 'true'
+      n_int = int(confs[5])
+      n_float = int(confs[6])
+      n_string = int(confs[7])
+      self.edge(source='',
+                edge_type=(src_node_type, dst_node_type, edge_type),
+                decoder=self._make_vineyard_decoder(
+                  weighted, labeled, n_int, n_float, n_string))
+
+    return self
+
+  def _make_vineyard_decoder(self,
+      weighted, labeled, n_int, n_float, n_string):
+    attr_types = []
+    if n_int == 0 and n_float == 0 and n_string == 0:
+      attr_types = None
+    else:
+      attr_types.extend(["int"] * n_int)
+      attr_types.extend(["float"] * n_float)
+      attr_types.extend(["string"] * n_string)
+    return data.Decoder(weighted, labeled, attr_types)
 
   def node(self,
            source,
@@ -113,6 +223,53 @@ class Graph(object):
     self._node_decoders[node_type] = decoder
     node_source = self._construct_node_source(source, node_type, decoder, option)
     self._node_sources.append(node_source)
+    return self
+
+  def _copy_node_source(self, node):
+    result = pywrap.NodeSource()
+    result.path = node.path
+    result.id_type = node.id_type
+    result.format = node.format
+    result.attr_info = node.attr_info
+    result.option = node.option
+    result.view_type = node.view_type
+    result.use_attrs = node.use_attrs
+    return result
+
+  def node_view(self, node_type, mask=utils.Mask.NONE, seed=0, nsplit=1, split_range=(0, 1)):
+    """ Add a virtual view of given `node_type` to split nodes into train/val/test set
+        without duplicately loading the graph.
+
+        It is for vineyard backend only.
+    """
+    assert self._with_vineyard, "node_view() is only for vineyard backend"
+    node_source = None
+    for node in self._node_sources:
+      if node.id_type == node_type:
+        node_source = self._copy_node_source(node)
+        break
+    if node_source is None:
+      raise ValueError('Node type "%s" doesn\'t exist.' % (node_type,))
+    masked_node_type = utils.get_mask_type(node_type, mask)
+    node_source.id_type = masked_node_type
+    node_source.view_type = '%s:%d:%d:%d:%d' % (node_type, seed, nsplit,
+                                                split_range[0], split_range[1])
+    self._node_decoders[masked_node_type] = self._node_decoders[node_type]
+    self._node_sources.append(node_source)
+    return self
+
+  def node_attributes(self, node_type, attrs, n_int, n_float, n_string):
+    node_source = None
+    for node in self._node_sources:
+      if node.id_type == node_type:
+        node_source = node
+        break
+    if node_source is None:
+      raise ValueError('Node type "%s" doesn\'t exist.' % (node_type,))
+    node_source.use_attrs = ';'.join(attrs)
+    decoder = self._node_decoders[node_type]
+    self._node_decoders[node_type] = self._make_vineyard_decoder(
+      decoder.weighted, decoder.labeled, n_int, n_float, n_string)
     return self
 
   def edge(self,
@@ -157,6 +314,34 @@ class Graph(object):
 
     if not directed:
       self.add_reverse_edges(edge_type, source, decoder, option)
+    return self
+
+  def _copy_edge_source(self, edge):
+    result = pywrap.EdgeSource()
+    result.path = edge.path
+    result.edge_type = edge.edge_type
+    result.src_id_type = edge.src_id_type
+    result.dst_id_type = edge.dst_id_type
+    result.format = edge.format
+    result.direction = edge.direction
+    result.attr_info = edge.attr_info
+    result.option = edge.option
+    result.view_type = edge.view_type
+    result.use_attrs = edge.use_attrs
+    return result
+
+  def edge_attributes(self, edge_type, attrs, n_int, n_float, n_string):
+    edge_source = None
+    for edge in self._edge_sources:
+      if edge.edge_type == edge_type:
+        edge_source = edge
+        break
+    if edge_source is None:
+      raise ValueError('edge type "%s" doesn\'t exist.' % (edge_type,))
+    edge_source.use_attrs = ';'.join(attrs)
+    decoder = self._edge_decoders[edge_type]
+    self._edge_decoders[edge_type] = self._make_vineyard_decoder(
+      decoder.weighted, decoder.labeled, n_int, n_float, n_string)
     return self
 
   @property
@@ -221,31 +406,41 @@ class Graph(object):
       kwargs:
         tracker (string): Optional tracker path for WORKER mode.
         hosts (string): Optional worker hosts for WORKER mode.
+        server_own (bool): Optional, TODO, default is False.
     """
+    if self._with_vineyard:
+      pywrap.set_storage_mode(8)
+      pywrap.set_tracker_mode(0)
+
+    if "server_own" in kwargs:
+      extra_args = {"server_own": kwargs["server_own"]}
+    else:
+      extra_args = {}
+
     if not cluster and task_count == 1:
       # Local mode
       pywrap.set_deploy_mode(pywrap.DeployMode.LOCAL)
-      self.deploy_in_local_mode()
+      self.deploy_in_local_mode(task_index, **extra_args)
     elif not cluster:
       if task_count > 1 or kwargs.get("hosts") is not None:
         # WORKER mode
         pywrap.set_deploy_mode(pywrap.DeployMode.WORKER)
         tracker = kwargs.get("tracker", "root://graphlearn")
         hosts = kwargs.get("hosts")
-        self.deploy_in_worker_mode(tracker, hosts, task_index, task_count)
+        self.deploy_in_worker_mode(tracker, hosts, task_index, task_count, **extra_args)
     else:
       # SERVER mode
       pywrap.set_deploy_mode(pywrap.DeployMode.SERVER)
-      self.deploy_in_server_mode(task_index, cluster, job_name)
+      self.deploy_in_server_mode(task_index, cluster, job_name, **extra_args)
     return self
 
-  def deploy_in_local_mode(self):
-    self._client = pywrap.in_memory_client()
+  def deploy_in_local_mode(self, task_index, **extra_args):
+    self._client = Client(client_id=task_index, **extra_args)
     self._server = Server(0, 1, "", "")
     self._server.start()
     self._server.init(self._edge_sources, self._node_sources)
 
-  def deploy_in_worker_mode(self, tracker, hosts, task_index, task_count):
+  def deploy_in_worker_mode(self, tracker, hosts, task_index, task_count, **extra_args):
     if hosts:
       pywrap.set_server_hosts(hosts)
       hosts = hosts.split(',')
@@ -261,12 +456,12 @@ class Graph(object):
     pywrap.set_server_count(task_count)
     pywrap.set_tracker(tracker)
 
-    self._client = pywrap.in_memory_client()
+    self._client = Client(client_id=task_index, **extra_args)
     self._server = Server(task_index, task_count, host, tracker)
     self._server.start()
     self._server.init(self._edge_sources, self._node_sources)
 
-  def deploy_in_server_mode(self, task_index, cluster, job_name):
+  def deploy_in_server_mode(self, task_index, cluster, job_name, **extra_args):
     if isinstance(cluster, dict):
       cluster_spec = cluster
     elif isinstance(cluster, str):
@@ -299,7 +494,7 @@ class Graph(object):
     if job_name == "client":
       pywrap.set_tracker(tracker)
       pywrap.set_client_id(task_index)
-      self._client = pywrap.rpc_client()
+      self._client = Client(client_id=task_index, in_memory=False, **extra_args)
       self._server = None
     elif job_name == "server":
       self._client = None
@@ -312,6 +507,28 @@ class Graph(object):
 
   def add_dataset(self, ds):
     self._datasets.append(ds)
+
+  def init_vineyard(self, server_index=None, worker_index=None, worker_count=None,
+                    standalone=False, server_own=True):
+    if not self._with_vineyard:
+      raise ValueError('Not a vineyard graph')
+
+    if standalone:
+      self.init()
+      return self
+
+    if server_index is None and worker_index is None:
+      raise ValueError('Cannot decide to launch a server or a worker')
+    if server_index is not None and worker_index is not None:
+      raise ValueError('Cannot be a server and a worker at the same unless standalone is True')
+
+    cluster = {'server': self._vineyard_handle['server'],
+               'client_count': self._vineyard_handle['client_count']}
+    if server_index is not None:
+      self.init(cluster=cluster, task_index=server_index, job_name="server", server_own=server_own)
+    else:
+      self.init(cluster=cluster, task_index=worker_index, job_name="client", server_own=server_own)
+    return self
 
   def close(self):
     self.wait_for_close()

--- a/graphlearn/python/gsl/dag_dataset.py
+++ b/graphlearn/python/gsl/dag_dataset.py
@@ -42,7 +42,7 @@ class Dataset(object):
     raise_exception_on_not_ok_status(status)
 
     pywrap.set_dataset_capacity(window)
-    self._dag_dataset = pywrap.Dataset(client, self._dag_id)
+    self._dag_dataset = pywrap.Dataset(client.current_client, self._dag_id)
     graph.add_dataset(self)
 
   def next(self):

--- a/graphlearn/python/gsl/dag_dataset.py
+++ b/graphlearn/python/gsl/dag_dataset.py
@@ -36,14 +36,21 @@ class Dataset(object):
     self._dag_id = dag.name
     self._cur_res = None
 
-    graph = dag.graph
-    client = graph.get_client()
-    status = client.run_dag(self._dag.dag_def)
-    raise_exception_on_not_ok_status(status)
+    self._graph = dag.graph
+    self._client = self._graph.get_client()
+    self._dag_datasets = [None] * len(self._client)
+    self._current_index = 0
 
     pywrap.set_dataset_capacity(window)
-    self._dag_dataset = pywrap.Dataset(client.current_client, self._dag_id)
-    graph.add_dataset(self)
+
+    # initialize the dataset for the first client
+    # note that the dag_def may need to be copied to avoid been moved
+    status = self._client.run_dag(self._dag.dag_def, self._current_index != len(self._client) - 1)
+    raise_exception_on_not_ok_status(status)
+    self._dag_datasets[self._current_index] = pywrap.Dataset(self._client.current_client, self._dag_id)
+
+    # associate to graph to delete it when the graph been deleted
+    self._graph.add_dataset(self)
 
   def next(self):
     # Delete the response of last round.
@@ -54,7 +61,7 @@ class Dataset(object):
     state = global_dag_state.get(self._dag.name)
 
     # Fill response.
-    res = self._dag_dataset.next(state)
+    res = self._dag_datasets[self._current_index].next(state)
 
     if res and res.valid():
       dag_values = DagValues(self._dag, res)
@@ -62,14 +69,29 @@ class Dataset(object):
       self._cur_res = res
       return result
     else:
-      global_dag_state.inc(self._dag.name)
+      # drop the last step response
       if res:
         pywrap.del_get_dag_value_response(res)
       self._cur_res = None
-      raise OutOfRangeError("OutOfRange")
+
+      if self._client.connect_to_next_server():
+        self._current_index = (self._current_index + 1) % len(self._client)
+        # initialize the dataset for the next client
+        if self._dag_datasets[self._current_index] is None:
+          status = self._client.run_dag(self._dag.dag_def, self._current_index != len(self._client) - 1)
+          raise_exception_on_not_ok_status(status)
+          self._dag_datasets[self._current_index] = pywrap.Dataset(self._client.current_client, self._dag_id)
+        return self.next()
+      else:
+        self._current_index = 0
+        # start the next epoch
+        global_dag_state.inc(self._dag.name)
+        raise OutOfRangeError("OutOfRange: end of epoch")
 
   def close(self):
-    self._dag_dataset.close()
+    for dataset in self._dag_datasets:
+      if dataset is not None:
+        dataset.close()
 
 
 class DagValues(object):

--- a/graphlearn/python/sampler/edge_sampler.py
+++ b/graphlearn/python/sampler/edge_sampler.py
@@ -78,7 +78,16 @@ class EdgeSampler(object):
 
     status = self._client.get_edges(req, res)
     if not status.ok():
-      self._graph.edge_state.inc(mask_type)
+      if self._client.connect_to_next_server():
+        req = pywrap.new_get_edges_request(
+          mask_type, self._strategy, self._batch_size, state)
+        res = pywrap.new_get_edges_response()
+        status = self._client.get_edges(req, res)
+        src_ids = pywrap.get_edge_src_id(res)
+        dst_ids = pywrap.get_edge_dst_id(res)
+        edge_ids = pywrap.get_edge_id(res)
+      else:
+        self._graph.edge_state.inc(mask_type)
     else:
       src_ids = pywrap.get_edge_src_id(res)
       dst_ids = pywrap.get_edge_dst_id(res)

--- a/graphlearn/python/sampler/node_sampler.py
+++ b/graphlearn/python/sampler/node_sampler.py
@@ -100,20 +100,14 @@ class NodeSampler(object):
 
     res = pywrap.new_get_nodes_response()
     status = self._client.get_nodes(req, res)
-    if not status.ok():
-      if self._client.connect_to_next_server():
-        req = pywrap.new_get_nodes_request(mask_type,
-                                           self._strategy,
-                                           self._node_from,
-                                           self._batch_size,
-                                           state)
-        res = pywrap.new_get_nodes_response()
-        status = self._client.get_nodes(req, res)
-        ids = pywrap.get_node_ids(res)
+    if status.ok():
+      ids = pywrap.get_node_ids(res)
+    else:
+      if status.code() == errors.OUT_OF_RANGE:
+        if self._client.connect_to_next_server():
+          return self.get()
       else:
         self._graph.node_state.inc(mask_type)
-    else:
-      ids = pywrap.get_node_ids(res)
 
     pywrap.del_op_response(res)
     pywrap.del_op_request(req)

--- a/graphlearn/python/sampler/node_sampler.py
+++ b/graphlearn/python/sampler/node_sampler.py
@@ -101,7 +101,17 @@ class NodeSampler(object):
     res = pywrap.new_get_nodes_response()
     status = self._client.get_nodes(req, res)
     if not status.ok():
-      self._graph.node_state.inc(mask_type)
+      if self._client.connect_to_next_server():
+        req = pywrap.new_get_nodes_request(mask_type,
+                                           self._strategy,
+                                           self._node_from,
+                                           self._batch_size,
+                                           state)
+        res = pywrap.new_get_nodes_response()
+        status = self._client.get_nodes(req, res)
+        ids = pywrap.get_node_ids(res)
+      else:
+        self._graph.node_state.inc(mask_type)
     else:
       ids = pywrap.get_node_ids(res)
 

--- a/graphlearn/python/utils.py
+++ b/graphlearn/python/utils.py
@@ -55,6 +55,8 @@ def get_mask_type(raw_type, mask=Mask.NONE):
   VAL mask for raw_type of "user, return "MASK***user".
   """
   assert isinstance(raw_type, str)
+  if isinstance(mask, str):  # accept string type
+    mask = Mask[mask.upper()]
   assert isinstance(mask, Mask)
   if mask == Mask.NONE:
     return raw_type

--- a/graphlearn/setup/version.py
+++ b/graphlearn/setup/version.py
@@ -1,0 +1,15 @@
+# Copyright 2020 Alibaba Group Holding Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# =============================================================================
+

--- a/graphlearn/src/common/base/progress.h
+++ b/graphlearn/src/common/base/progress.h
@@ -55,7 +55,7 @@ struct Progress {
     if (count > stage * grading) {
       char buffer[100];
       snprintf(buffer, sizeof(buffer),
-               "Progress of %s: %ld", key.c_str(), stage * grading);
+               "Progress of %s: %lld", key.c_str(), (long long)(stage * grading));
       USER_LOG(buffer);
       ++stage;
     }

--- a/graphlearn/src/core/graph/storage/vineyard_graph_storage.h
+++ b/graphlearn/src/core/graph/storage/vineyard_graph_storage.h
@@ -60,20 +60,10 @@ public:
     std::cerr << std::endl;
 
     VINEYARD_CHECK_OK(client_.Connect(GLOBAL_FLAG(VineyardIPCSocket)));
-    auto fg = client_.GetObject<vineyard::ArrowFragmentGroup>(
-        GLOBAL_FLAG(VineyardGraphID));
-    if (fg == nullptr) {
-      throw std::runtime_error("Graph: failed to find the graph");
-    }
-    // assume 1 worker per server
-    for (const auto& kv : fg->Fragments()) {
-      if (fg->FragmentLocations().at(kv.first) == client_.instance_id()) {
-        frag_ = client_.GetObject<gl_frag_t>(kv.second);
-        break;
-      }
-    }
+    frag_ = get_vineyard_fragment(client_, GLOBAL_FLAG(VineyardGraphID));
     if (frag_ == nullptr) {
-      throw std::runtime_error("Graph: failed to find a local fragment");
+      throw std::runtime_error(
+        "Graph: failed to find the vineyard fragment: " + GLOBAL_FLAG(VineyardGraphID));
     }
     vertex_map_ = frag_->GetVertexMap();
 

--- a/graphlearn/src/core/graph/storage/vineyard_storage_utils.cc
+++ b/graphlearn/src/core/graph/storage/vineyard_storage_utils.cc
@@ -413,7 +413,7 @@ SideInfo *frag_node_side_info(const std::shared_ptr<gl_frag_t>& frag,
   if (cache_entry) {
     return cache_entry.get();
   }
-  std::cerr << "init node sideinfo " << frag->id();
+  std::cerr << "init node sideinfo " << frag->id() << std::endl;
   auto side_info = std::make_shared<SideInfo>();
   // compute attribute numbers of i/f/s
   auto node_table = frag->vertex_data_table(node_label);

--- a/graphlearn/src/core/graph/storage/vineyard_storage_utils.h
+++ b/graphlearn/src/core/graph/storage/vineyard_storage_utils.h
@@ -20,6 +20,7 @@ limitations under the License.
 #include <set>
 
 #if defined(WITH_VINEYARD)
+#include "boost/algorithm/string.hpp"
 #include "vineyard/graph/fragment/arrow_fragment.vineyard.h"
 #endif
 

--- a/graphlearn/src/core/graph/storage/vineyard_storage_utils.h
+++ b/graphlearn/src/core/graph/storage/vineyard_storage_utils.h
@@ -55,6 +55,9 @@ using graphlearn::io::IndexArray;
 using graphlearn::io::NewDataHeldAttributeValue;
 using graphlearn::io::SideInfo;
 
+std::shared_ptr<gl_frag_t> get_vineyard_fragment(vineyard::Client &client,
+                                                 const vineyard::ObjectID object_id);
+
 void init_table_accessors(const std::shared_ptr<arrow::Table>& table,
                           const std::set<std::string>& attrs,
                           std::vector<int>& i32_indexes,

--- a/graphlearn/src/include/client.h
+++ b/graphlearn/src/include/client.h
@@ -65,7 +65,7 @@ public:
 private:
   explicit Client(ClientImpl* impl, bool own = true);
   friend Client* NewInMemoryClient();
-  friend Client* NewRpcClient(int32_t server_id, bool server_own,
+  friend Client* NewRpcClient(int32_t server_id,
                               bool client_own);
 
 private:
@@ -74,7 +74,7 @@ private:
 };
 
 Client* NewInMemoryClient();
-Client* NewRpcClient(int32_t server_id = -1, bool server_own = true,
+Client* NewRpcClient(int32_t server_id = -1,
                      bool client_own = false);
 
 }  // namespace graphlearn

--- a/graphlearn/src/include/dag_request.h
+++ b/graphlearn/src/include/dag_request.h
@@ -32,6 +32,7 @@ public:
   DagRequest();
   void SerializeTo(void* request) override;
   bool ParseFrom(const void* request) override;
+  bool ParseFrom(const void* request, const bool copy=false);
 
   std::string Name() const override;
 

--- a/graphlearn/src/service/client.cc
+++ b/graphlearn/src/service/client.cc
@@ -94,7 +94,7 @@ public:
     }
   }
 
-  ClientImpl* LookupOrCreate(int32_t server_id, bool server_own) {
+  ClientImpl* LookupOrCreate(int32_t server_id) {
     if (server_id >= GLOBAL_FLAG(ServerCount)) {
       LOG(FATAL) << "Unexpected server id: " << server_id;
       return nullptr;
@@ -102,7 +102,7 @@ public:
 
     ScopedLocker<std::mutex> _(&mtx_);
     if (clients_[server_id] == nullptr) {
-      ClientImpl* c = NewRpcClientImpl(server_id, server_own);
+      ClientImpl* c = NewRpcClientImpl(server_id);
       clients_[server_id] = c;
     }
     return clients_[server_id];
@@ -113,13 +113,13 @@ private:
   std::vector<ClientImpl*> clients_;
 };
 
-Client* NewRpcClient(int32_t server_id, bool server_own, bool client_own) {
+Client* NewRpcClient(int32_t server_id, bool client_own) {
   static ClientManager manager;
   if (server_id < 0 || client_own) {
     // auto select
-    return new Client(NewRpcClientImpl(server_id, server_own), true);
+    return new Client(NewRpcClientImpl(server_id), true);
   } else {
-    return new Client(manager.LookupOrCreate(server_id, server_own), false);
+    return new Client(manager.LookupOrCreate(server_id), false);
   }
 }
 

--- a/graphlearn/src/service/client_impl.h
+++ b/graphlearn/src/service/client_impl.h
@@ -45,7 +45,7 @@ protected:
 };
 
 ClientImpl* NewInMemoryClientImpl();
-ClientImpl* NewRpcClientImpl(int32_t server_id, bool server_own = true);
+ClientImpl* NewRpcClientImpl(int32_t server_id);
 
 }  // namespace graphlearn
 

--- a/graphlearn/src/service/dist/grpc_client.cc
+++ b/graphlearn/src/service/dist/grpc_client.cc
@@ -26,10 +26,8 @@ namespace graphlearn {
 
 class GrpcClientImpl : public ClientImpl {
 public:
-  GrpcClientImpl(int32_t server_id, bool server_own) : server_own_(server_own) {
-    if (!server_own_) {
-      InitGoogleLogging();
-    }
+  GrpcClientImpl(int32_t server_id) {
+    InitGoogleLogging();
 
     manager_ = ChannelManager::GetInstance();
     manager_->SetCapacity(GLOBAL_FLAG(ServerCount));
@@ -42,9 +40,7 @@ public:
   }
 
   virtual ~GrpcClientImpl() {
-    if (!server_own_) {
-      UninitGoogleLogging();
-    }
+    UninitGoogleLogging();
   }
 
   Status RunOp(const OpRequest* request,
@@ -143,11 +139,10 @@ private:
 private:
   ChannelManager* manager_;
   GrpcChannel*    channel_;
-  bool            server_own_;
 };
 
-ClientImpl* NewRpcClientImpl(int32_t server_id, bool server_own) {
-  return new GrpcClientImpl(server_id, server_own);
+ClientImpl* NewRpcClientImpl(int32_t server_id) {
+  return new GrpcClientImpl(server_id);
 }
 
 }  // namespace graphlearn

--- a/graphlearn/src/service/request/dag_request.cc
+++ b/graphlearn/src/service/request/dag_request.cc
@@ -34,6 +34,16 @@ bool DagRequest::ParseFrom(const void* request) {
   return true;
 }
 
+bool DagRequest::ParseFrom(const void* request, const bool copy) {
+  DagDef* pb = const_cast<DagDef*>(static_cast<const DagDef*>(request));
+  if (copy) {
+    def_ = *pb;
+  } else {
+    def_.Swap(pb);
+  }
+  return true;
+}
+
 std::string DagRequest::Name() const {
   return "DagRequest";
 }


### PR DESCRIPTION
This pull request picks up necessary routines to support using graphlearn in the context of graphscope (see also the original work in https://github.com/alibaba/graph-learn/commit/e56fc9c8bc92f68eb308b5a91680d7f6abdce57a).

This pull request has done a lot of cleanup and simplification, the main changes there are:

- Add a `Client` class to support connecting to multiple servers from one client
- Add basic routines that need to wrap a vineyard graph to use in graphlearn.