### PR TITLE
Probe for c++17 support and fallback to c++14.

### DIFF
--- a/graphlearn/CMakeLists.txt
+++ b/graphlearn/CMakeLists.txt
@@ -16,6 +16,8 @@ cmake_minimum_required (VERSION 3.13)
 
 project (GraphLearn VERSION 1.0 LANGUAGES CXX)
 
+include(CheckCXXCompilerFlag)
+
 ## options
 option (TESTING
   "Enable testing"
@@ -338,7 +340,12 @@ else()
 endif()
 
 if (WITH_VINEYARD)
-  set (GL_CXX_DIALECT "c++14")
+  CHECK_CXX_COMPILER_FLAG("-std=gnu++17" HAS_STDCXX_17)
+  if (HAS_STDCXX_17)
+    set (GL_CXX_DIALECT "gnu++17")
+  else()
+    set (GL_CXX_DIALECT "gnu++14")
+  endif()
 endif()
 
 if (WITH_HIACTOR)
@@ -511,7 +518,7 @@ if (TESTING)
   endif ()
 
   if (WITH_VINEYARD AND TARGET vineyard_storage_unittest)
-    target_compile_options(vineyard_storage_unittest PRIVATE "-std=c++14")
+    target_compile_options(vineyard_storage_unittest PRIVATE "-std=${GL_CXX_DIALECT}")
   endif ()
 endif()
 

--- a/graphlearn/src/common/base/config.cc
+++ b/graphlearn/src/common/base/config.cc
@@ -16,6 +16,7 @@ limitations under the License.
 #include "include/config.h"
 
 #include <algorithm>
+#include <limits>
 
 namespace graphlearn {
 


### PR DESCRIPTION
Fix errors when compiling with `g++==11.3.0`, `arrow==10.0.0`, vineyard==`0.11.3`

Errors:
```
 /usr/include/arrow/array/builder_dict.h:278:24: note: 'std::string_view' is only available from C++17 onwards
  /usr/include/arrow/array/builder_dict.h: In member function 'arrow::enable_if_string_like<T1, arrow::Status> arrow::internal::DictionaryBuilderBase<BuilderType, T>::Append(const char*, int32_t)':
  /usr/include/arrow/array/builder_dict.h:284:24: error: 'string_view' is not a member of 'std'
    284 |     return Append(std::string_view(value, length));
        |                        ^~~~~~~~~~~
  /usr/include/arrow/array/builder_dict.h:284:24: note: 'std::string_view' is only available from C++17 onwards
  /opt/graphscope/lib/cmake/vineyard/../../../include/vineyard/graph/vertex_map/arrow_local_vertex_map.h:129:31: error: 'arrow_string_view' was not declared in this scope
    129 |           ArrowLocalVertexMap<arrow_string_view, VID_T>> {
        |                               ^~~~~~~~~~~~~~~~~
  /opt/graphscope/lib/cmake/vineyard/../../../include/vineyard/graph/vertex_map/arrow_local_vertex_map.h:129:50: error: template argument 1 is invalid
    129 |           ArrowLocalVertexMap<arrow_string_view, VID_T>> {
        |                                                  ^~~~~
  /opt/graphscope/lib/cmake/vineyard/../../../include/vineyard/graph/vertex_map/arrow_local_vertex_map.h:129:55: error: template argument 1 is invalid
    129 |           ArrowLocalVertexMap<arrow_string_view, VID_T>> {
        |                                                       ^~
  /opt/graphscope/lib/cmake/vineyard/../../../include/vineyard/graph/vertex_map/arrow_local_vertex_map.h:259:34: error: 'arrow_string_view' was not declared in this scope
    259 | class ArrowLocalVertexMapBuilder<arrow_string_view, VID_T>
        |                                  ^~~~~~~~~~~~~~~~~
  /opt/graphscope/lib/cmake/vineyard/../../../include/vineyard/graph/vertex_map/arrow_local_vertex_map.h:259:58: error: template argument 1 is invalid
    259 | class ArrowLocalVertexMapBuilder<arrow_string_view, VID_T>
        |                                                
```