### PR TITLE
Fixes the "illegal thread local variable reference to regular symbol" error on MacOS

### DIFF
--- a/graphlearn/CMakeLists.txt
+++ b/graphlearn/CMakeLists.txt
@@ -553,8 +553,8 @@ add_custom_command (TARGET python
   COMMAND cp -f ${GL_SETUP_DIR}/version.py ${GL_PYTHON_DIR}/python/version.py
   COMMAND echo "__version__ = ${VERSION}" >> ${GL_PYTHON_DIR}/python/version.py
   COMMAND echo "__git_version__ = '${GIT_BRANCH}-${GIT_VERSION}'" >> ${GL_PYTHON_DIR}/python/version.py
-  COMMAND OPEN_KNN=${KNN_FLAG} CXX_DIALECT=${GL_CXX_DIALECT} ${GL_PYTHON_BIN} ${GL_SETUP_DIR}/setup.py build_ext --inplace
-  COMMAND OPEN_KNN=${KNN_FLAG} CXX_DIALECT=${GL_CXX_DIALECT} ${GL_PYTHON_BIN} ${GL_SETUP_DIR}/setup.py bdist_wheel
+  COMMAND OPEN_KNN=${KNN_FLAG} CXX_DIALECT=${GL_CXX_DIALECT} Protobuf_LIBRARIES=${Protobuf_LIBRARIES} ${GL_PYTHON_BIN} ${GL_SETUP_DIR}/setup.py build_ext --inplace
+  COMMAND OPEN_KNN=${KNN_FLAG} CXX_DIALECT=${GL_CXX_DIALECT} Protobuf_LIBRARIES=${Protobuf_LIBRARIES} ${GL_PYTHON_BIN} ${GL_SETUP_DIR}/setup.py bdist_wheel
   COMMAND ${CMAKE_COMMAND} -E make_directory "${GL_BUILT_BIN_DIR}/ge_data/data"
   COMMAND ${CMAKE_COMMAND} -E make_directory "${GL_BUILT_BIN_DIR}/ge_data/ckpt"
   WORKING_DIRECTORY ${GL_ROOT}

--- a/graphlearn/setup/setup.py
+++ b/graphlearn/setup/setup.py
@@ -31,6 +31,7 @@ ROOT_PATH = os.path.abspath(os.path.join(os.getcwd()))
 CUT_PATH = sys.path[0]
 OPEN_KNN = os.getenv('OPEN_KNN', 'CLOSE')
 CXX_DIALECT = os.getenv('CXX_DIALECT', 'c++11')
+Protobuf_LIBRARIES = os.getenv('Protobuf_LIBRARIES', '')
 
 extensions = []
 include_dirs = []
@@ -61,6 +62,12 @@ if sys.platform == 'linux' or sys.platform == 'linux2':
 libraries.append('graphlearn_shared')
 # if OPEN_KNN == 'OPEN':
 #   libraries.append('knn_shared')
+
+# explicitly link against protobuf to avoid the error
+# "illegal thread local variable reference to regular symbol"
+if sys.platform == 'darwin':
+  if Protobuf_LIBRARIES:
+    extra_link_args.append(Protobuf_LIBRARIES)
 
 sources = [ROOT_PATH + '/python/c/py_export.cc',
            ROOT_PATH + '/python/c/py_client.cc']

--- a/graphlearn/src/include/graph_request.h
+++ b/graphlearn/src/include/graph_request.h
@@ -30,7 +30,7 @@ namespace io {
 struct SideInfo;
 struct EdgeValue;
 struct NodeValue;
-struct AttributeValue;
+class AttributeValue;
 }  // namespace io
 
 class UpdateRequest : public OpRequest {


### PR DESCRIPTION
See also:
- https://github.com/alibaba/GraphScope/actions/runs/5438100852/jobs/9889099878