### PR TITLE
save embedding of unsupervised graphsage

### DIFF
--- a/graphlearn/examples/tf/ego_sage/train_unsupervised.py
+++ b/graphlearn/examples/tf/ego_sage/train_unsupervised.py
@@ -68,6 +68,43 @@ def load_graph(args):
           decoder=gl.Decoder(weighted=True), directed=False)
   return g
 
+def meta_path_sample(ego, node_type, edge_type, ego_name, nbrs_num, sampler):
+    """ creates the meta-math sampler of the input ego.
+    Args:
+    ego: A query object, the input centric nodes/edges
+    ego_type: A string, the type of `ego`, node_type such as 'paper' or 'user'.
+    ego_name: A string, the name of `ego`.
+    nbrs_num: A list, the number of neighbors for each hop.
+    sampler: A string, the strategy of neighbor sampling.
+    """
+    meta_path = []
+    hops = range(len(nbrs_num))
+    meta_path = ['outV' for i in hops]
+    alias_list = [ego_name + '_hop_' + str(i + 1) for i in hops]
+    mata_path_string = ""
+    for path, nbr_count, alias in zip(meta_path, nbrs_num, alias_list):
+        mata_path_string += path + '(' + edge_type + ').'
+        ego = getattr(ego, path)(edge_type).sample(nbr_count).by(sampler).alias(alias)
+    print("Sampling meta path for {} is {}.".format(node_type, mata_path_string))
+    return ego
+
+def node_embedding(graph, model, node_type, edge_type, **kwargs):
+    """ save node embedding.
+
+    Args:
+    node_type: such as 'paper' or 'user'. 
+    edge_type: such as 'node_type' or 'edge_type'.
+    Return:
+    iterator, ids, embedding.
+    """
+    tfg.conf.training = False
+    ego_name = 'save_node_' + node_type
+    seed = graph.V(node_type).batch(kwargs.get('batch_size', 64)).alias(ego_name)
+    query_save = meta_path_sample(seed, node_type, edge_type, ego_name, kwargs.get('nbrs_num', [10, 5]), kwargs.get('sampler', 'random_without_replacement')).values()
+    dataset = tfg.Dataset(query_save, window=kwargs.get('window', 10))
+    ego_graph = dataset.get_egograph(ego_name)
+    emb = model.forward(ego_graph)
+    return dataset.iterator, ego_graph.src.ids, emb
 
 def run(args):
   # graph input data
@@ -82,6 +119,10 @@ def run(args):
   # prepare train dataset
   train_data = EgoSAGEUnsupervisedDataLoader(g, None, args.sampler, args.neg_sampler, args.batch_size,
                                              node_type='i', edge_type='train', nbrs_num=args.nbrs_num)
+
+  ## uncomment below line will save the embeddings
+  # save_iter, save_ids, save_emb = node_embedding(graph=lg, model=model, node_type=node_type, edge_type=edge_type)
+
   src_emb = model.forward(train_data.src_ego)
   dst_emb = model.forward(train_data.dst_ego)
   neg_dst_emb = model.forward(train_data.neg_dst_ego)
@@ -92,6 +133,11 @@ def run(args):
   # train
   trainer = LocalTrainer()
   trainer.train(train_data.iterator, loss, optimizer, epochs=args.epochs)
+  ## uncomment below lines will save the embeddings
+  # save_file = './car_emb.txt'
+  # trainer.train_and_save(train_data.iterator, loss, optimizer, epochs=epochs, save_file=save_file, hooks=[], 
+  #                      save_iter=save_iter, save_ids=save_ids, save_emb=save_emb,
+  #                      graph=g, model=model, node_type=node_type, edge_type=edge_type, block_max_lines=200000)
 
   # finish
   g.close()

--- a/graphlearn/examples/tf/ego_sage/train_unsupervised.py
+++ b/graphlearn/examples/tf/ego_sage/train_unsupervised.py
@@ -136,8 +136,9 @@ def run(args):
   ## uncomment below lines will save the embeddings
   # save_file = './car_emb.txt'
   # trainer.train_and_save(train_data.iterator, loss, optimizer, epochs=epochs, save_file=save_file, hooks=[], 
-  #                      save_iter=save_iter, save_ids=save_ids, save_emb=save_emb,
-  #                      graph=g, model=model, node_type=node_type, edge_type=edge_type, block_max_lines=200000)
+  #                        save_iter=save_iter, save_ids=save_ids, save_emb=save_emb,
+  #                        graph=g, model=model, node_type=node_type, edge_type=edge_type, 
+  #                        block_max_lines=200000, batch_size=batch_size)
 
   # finish
   g.close()

--- a/graphlearn/examples/tf/ego_sage/train_unsupervised.py
+++ b/graphlearn/examples/tf/ego_sage/train_unsupervised.py
@@ -121,7 +121,7 @@ def run(args):
                                              node_type='i', edge_type='train', nbrs_num=args.nbrs_num)
 
   ## uncomment below line will save the embeddings
-  # save_iter, save_ids, save_emb = node_embedding(graph=lg, model=model, node_type=node_type, edge_type=edge_type)
+  # save_iter, save_ids, save_emb = node_embedding(graph=lg, model=model, node_type=node_type, edge_type=edge_type, nbrs_num=args.nbr_num)
 
   src_emb = model.forward(train_data.src_ego)
   dst_emb = model.forward(train_data.dst_ego)

--- a/graphlearn/examples/tf/ego_sage/train_unsupervised.py
+++ b/graphlearn/examples/tf/ego_sage/train_unsupervised.py
@@ -134,11 +134,9 @@ def run(args):
   trainer = LocalTrainer()
   trainer.train(train_data.iterator, loss, optimizer, epochs=args.epochs)
   ## uncomment below lines will save the embeddings
-  # save_file = './car_emb.txt'
-  # trainer.train_and_save(train_data.iterator, loss, optimizer, epochs=epochs, save_file=save_file, hooks=[], 
-  #                        save_iter=save_iter, save_ids=save_ids, save_emb=save_emb,
-  #                        graph=g, model=model, node_type=node_type, edge_type=edge_type, 
-  #                        block_max_lines=200000, batch_size=batch_size)
+  # save_file = './emb.txt'
+  # trainer.save_node_embedding_bigdata(save_iter=save_iter, save_ids=save_ids, save_emb=save_emb, 
+  #                                     save_file=save_file, block_max_lines=100000, batch_size=batch_size)
 
   # finish
   g.close()

--- a/graphlearn/examples/tf/trainer.py
+++ b/graphlearn/examples/tf/trainer.py
@@ -162,7 +162,7 @@ class TFTrainer(object):
             last_global_step = global_step
       # save embedding
       self.save_node_embedding_bigdata(save_iter, save_ids, save_emb, save_file, 
-                                       kwargs.get('block_max_lines', 100000000))
+                                       kwargs.get('block_max_lines', 10000000))
       #
       if self.sync_barrier is not None:
         self.sync_barrier.end(self.sess)

--- a/graphlearn/examples/tf/trainer.py
+++ b/graphlearn/examples/tf/trainer.py
@@ -41,94 +41,6 @@ run_options = tf.RunOptions(trace_level=tf.RunOptions.FULL_TRACE)
 run_metadata = tf.RunMetadata()
 
 
-def meta_path_sample(ego, node_type, edge_type, ego_name, nbrs_num, sampler):
-    """ creates the meta-math sampler of the input ego.
-    Args:
-    ego: A query object, the input centric nodes/edges
-    ego_type: A string, the type of `ego`, node_type such as 'paper' or 'user'.
-    ego_name: A string, the name of `ego`.
-    nbrs_num: A list, the number of neighbors for each hop.
-    sampler: A string, the strategy of neighbor sampling.
-    """
-    meta_path = []
-    hops = range(len(nbrs_num))
-    meta_path = ['outV' for i in hops]
-    alias_list = [ego_name + '_hop_' + str(i + 1) for i in hops]
-    mata_path_string = ""
-    for path, nbr_count, alias in zip(meta_path, nbrs_num, alias_list):
-        mata_path_string += path + '(' + edge_type + ').'
-        ego = getattr(ego, path)(edge_type).sample(nbr_count).by(sampler).alias(alias)
-    print("Sampling meta path for {} is {}.".format(node_type, mata_path_string))
-    return ego
-
-def node_embedding(graph, model, node_type, edge_type, **kwargs):
-    """ save node embedding.
-
-    Args:
-    node_type: such as 'paper' or 'user'. 
-    edge_type: such as 'node_type' or 'edge_type'.
-    Return:
-    iterator, ids, embedding.
-    """
-    tfg.conf.training = False
-    ego_name = 'save_node_' + node_type
-    seed = graph.V(node_type).batch(kwargs.get('batch_size', 64)).alias(ego_name)
-    query_save = meta_path_sample(seed, node_type, edge_type, ego_name, kwargs.get('nbrs_num', [10, 5]), kwargs.get('sampler', 'random_without_replacement')).values()
-    dataset = tfg.Dataset(query_save, window=kwargs.get('window', 10))
-    ego_graph = dataset.get_egograph(ego_name)
-    emb = model.forward(ego_graph)
-    return dataset.iterator, ego_graph.src.ids, emb
-
-def dump_embedding(sess, save_iter, save_ids, save_emb, save_file, block_max_lines):
-    # assume block_max_lines >> batch_size
-    assert block_max_lines >= 10000, 'block_max_lines must >= 10000, it is {} now'.format(block_max_lines)
-    sess.run(save_iter.initializer)
-    total_line = 0
-    local_line = 0
-    block_id = 0
-    if save_file.endswith('.txt'):
-        save_file = save_file[:-4]
-    while True:
-        try:
-            outs = sess.run([save_ids, save_emb])
-            i_feat = ['%d\t'%i + ','.join(str(x) for x in arr) + '\n' for i, arr in zip(outs[0], outs[1])]
-            total_line += len(i_feat)
-            local_line += len(i_feat)
-            if local_line <= block_max_lines:
-                save_file_i = save_file +'_%d'%block_id + '.txt'
-                if not os.path.exists(save_file_i):
-                    with open(save_file_i, 'w') as f:
-                        f.write('id:int64\temb:string\n')  
-                with open(save_file_i, 'a') as f:
-                    f.writelines(i_feat)
-            elif block_max_lines < local_line < block_max_lines + len(i_feat):
-                save_file_i = save_file +'_%d'%block_id + '.txt'
-                with open(save_file_i, 'a') as f:
-                    f.writelines(i_feat[0: len(i_feat) - (local_line - block_max_lines)])
-                block_id += 1
-                save_file_i = save_file +'_%d'%block_id + '.txt' 
-                with open(save_file_i, 'a') as f:
-                    f.write('id:int64\temb:string\n')
-                    f.writelines(i_feat[len(i_feat) - (local_line - block_max_lines):])
-                local_line = local_line - block_max_lines
-            elif local_line == block_max_lines + len(i_feat):
-                block_id += 1
-                save_file_i = save_file +'_%d'%block_id + '.txt'
-                with open(save_file_i, 'a') as f:
-                    f.write('id:int64\temb:string\n')
-                    f.writelines(i_feat)
-                local_line = local_line - block_max_lines                
-            else:
-                assert local_line <= block_max_lines + len(i_feat), 'must local_line <= block_max_lines + len(i_feat)' 
-                
-        except tf.errors.OutOfRangeError:
-            print('Save node embeddings done.')
-            break
-    print("#################################################")
-    print("total lines save = {} , number blocks = {} ".format(total_line, block_id + 1))
-    print("#################################################")
-
-
 class TFTrainer(object):
   """Class for local or distributed training and evaluation.
 
@@ -194,12 +106,9 @@ class TFTrainer(object):
 
 
   def train_and_save(self, iterator, loss, optimizer=None, learning_rate=None,
-            epochs=10, hooks=[], save_file=None, save_ids=None, save_emb=None, **kwargs):
+            epochs=10, hooks=[], save_file=None, save_iter=None, save_ids=None, save_emb=None, **kwargs):
     with self.context():
       self.global_step = tf.train.get_or_create_global_step()
-      #   
-      save_iter, save_ids, save_emb = node_embedding(kwargs.get('graph'), kwargs.get('model'), kwargs.get('node_type'), kwargs.get('edge_type'))
-      print("Finisha get save_iter, save_ids, save_emb...")
       if optimizer is None:
         try:
           optimizer = tf.train.AdamAsyncOptimizer(learning_rate=learning_rate)
@@ -252,10 +161,8 @@ class TFTrainer(object):
             last_local_step = local_step
             last_global_step = global_step
       # save embedding
-      if os.path.exists(save_file):
-          os.remove(save_file)
-          print(save_file + " is removed")
-      dump_embedding(self.sess, save_iter, save_ids, save_emb, save_file, kwargs.get('block_max_lines', 100000000))
+      self.save_node_embedding_bigdata(self.sess, save_iter, save_ids, save_emb, save_file, 
+                                       kwargs.get('block_max_lines', 100000000))
       #
       if self.sync_barrier is not None:
         self.sync_barrier.end(self.sess)
@@ -367,6 +274,56 @@ class TFTrainer(object):
                          epochs=10, hooks=[], **kwargs):
     self.train(train_iterator, loss, optimizer, learning_rate, epochs, hooks, **kwargs)
     self.test(test_iterator, test_acc, hooks, **kwargs)
+
+  def save_node_embedding_bigdata(self, sess, save_iter, save_ids, save_emb, save_file, block_max_lines):
+      print('Start saving embeddings...')
+      # assume block_max_lines >> batch_size
+      assert block_max_lines >= 10000, 'block_max_lines must >= 10000, it is {} now'.format(block_max_lines)
+      sess.run(save_iter.initializer)
+      total_line = 0
+      local_line = 0
+      block_id = 0
+      if save_file.endswith('.txt'):
+          save_file = save_file[:-4]
+      while True:
+          try:
+              outs = sess.run([save_ids, save_emb])
+              i_feat = ['%d\t'%i + ','.join(str(x) for x in arr) + '\n' for i, arr in zip(outs[0], outs[1])]
+              total_line += len(i_feat)
+              local_line += len(i_feat)
+              if local_line <= block_max_lines:
+                  save_file_i = save_file +'_%d'%block_id + '.txt'
+                  if not os.path.exists(save_file_i):
+                      with open(save_file_i, 'w') as f:
+                          f.write('id:int64\temb:string\n')  
+                  with open(save_file_i, 'a') as f:
+                      f.writelines(i_feat)
+              elif block_max_lines < local_line < block_max_lines + len(i_feat):
+                  save_file_i = save_file +'_%d'%block_id + '.txt'
+                  with open(save_file_i, 'a') as f:
+                      f.writelines(i_feat[0: len(i_feat) - (local_line - block_max_lines)])
+                  block_id += 1
+                  save_file_i = save_file +'_%d'%block_id + '.txt' 
+                  with open(save_file_i, 'a') as f:
+                      f.write('id:int64\temb:string\n')
+                      f.writelines(i_feat[len(i_feat) - (local_line - block_max_lines):])
+                  local_line = local_line - block_max_lines
+              elif local_line == block_max_lines + len(i_feat):
+                  block_id += 1
+                  save_file_i = save_file +'_%d'%block_id + '.txt'
+                  with open(save_file_i, 'a') as f:
+                      f.write('id:int64\temb:string\n')
+                      f.writelines(i_feat)
+                  local_line = local_line - block_max_lines                
+              else:
+                  assert local_line <= block_max_lines + len(i_feat), 'must local_line <= block_max_lines + len(i_feat)' 
+                  
+          except tf.errors.OutOfRangeError:
+              print('Save node embeddings done.')
+              break
+      print("#################################################")
+      print("total lines save = {} , number blocks = {} ".format(total_line, block_id + 1))
+      print("#################################################")
 
   def save_node_embedding(self, emb_writer, iterator, ids, emb, batch_size):
     print('Start saving embeddings...')

--- a/graphlearn/examples/tf/trainer.py
+++ b/graphlearn/examples/tf/trainer.py
@@ -161,7 +161,7 @@ class TFTrainer(object):
             last_local_step = local_step
             last_global_step = global_step
       # save embedding
-      self.save_node_embedding_bigdata(self.sess, save_iter, save_ids, save_emb, save_file, 
+      self.save_node_embedding_bigdata(save_iter, save_ids, save_emb, save_file, 
                                        kwargs.get('block_max_lines', 100000000))
       #
       if self.sync_barrier is not None:
@@ -275,11 +275,11 @@ class TFTrainer(object):
     self.train(train_iterator, loss, optimizer, learning_rate, epochs, hooks, **kwargs)
     self.test(test_iterator, test_acc, hooks, **kwargs)
 
-  def save_node_embedding_bigdata(self, sess, save_iter, save_ids, save_emb, save_file, block_max_lines):
+  def save_node_embedding_bigdata(self, save_iter, save_ids, save_emb, save_file, block_max_lines):
       print('Start saving embeddings...')
       # assume block_max_lines >> batch_size
       assert block_max_lines >= 10000, 'block_max_lines must >= 10000, it is {} now'.format(block_max_lines)
-      sess.run(save_iter.initializer)
+      self.sess.run(save_iter.initializer)
       total_line = 0
       local_line = 0
       block_id = 0
@@ -287,7 +287,7 @@ class TFTrainer(object):
           save_file = save_file[:-4]
       while True:
           try:
-              outs = sess.run([save_ids, save_emb])
+              outs = self.sess.run([save_ids, save_emb])
               i_feat = ['%d\t'%i + ','.join(str(x) for x in arr) + '\n' for i, arr in zip(outs[0], outs[1])]
               total_line += len(i_feat)
               local_line += len(i_feat)


### PR DESCRIPTION
I added a method called train_and_save in trainer.py, which can train the unsupervised GraphSage model and save all node embeddings after training.

1. Changes:
(1) Added the save_node_embedding_bigdata method in trainer.py, which can save embeddings in several blocks; maximum lines in each block is limited by parameter 'block_max_lines'(default 10,000,000); when batch_size >= block_max_lines, it will use original save_node_embedding function.
(2) When I save the embedding with save_node_embedding, it encounters an error: 'TypeError: TextIOWrapper.write takes no keyword arguments'. I tried to solve it and found that the error lies in using .write to write a list of tuples. Therefore, I used .writelines to write a list of strings instead.
(3) Enriched the train_unsupervised.py file, which is added the usage of save_node_embedding_bigdata (the codes are commented out to avoid influencing the original code, but I believe these codes are very useful for beginners).

2. Usage of save_node_embedding_bigdata method is as follows:
```python
## Add the required functions in your `train.py` file
def meta_path_sample(ego, node_type, edge_type, ego_name, nbrs_num, sampler):
    """ creates the meta-math sampler of the input ego.
    Args:
    ego: A query object, the input centric nodes/edges
    ego_type: A string, the type of `ego`, node_type such as 'paper' or 'user'.
    ego_name: A string, the name of `ego`.
    nbrs_num: A list, the number of neighbors for each hop.
    sampler: A string, the strategy of neighbor sampling.
    """
    meta_path = []
    hops = range(len(nbrs_num))
    meta_path = ['outV' for i in hops]
    alias_list = [ego_name + '_hop_' + str(i + 1) for i in hops]
    mata_path_string = ""
    for path, nbr_count, alias in zip(meta_path, nbrs_num, alias_list):
        mata_path_string += path + '(' + edge_type + ').'
        ego = getattr(ego, path)(edge_type).sample(nbr_count).by(sampler).alias(alias)
    print("Sampling meta path for {} is {}.".format(node_type, mata_path_string))
    return ego

def node_embedding(graph, model, node_type, edge_type, **kwargs):
    """ Save node embeddings.

    Args:
    node_type: such as 'paper' or 'user'. 
    edge_type: such as 'node_type' or 'edge_type'.
    Return:
    iterator, ids, embedding.
    """
    tfg.conf.training = False
    ego_name = 'save_node_' + node_type
    seed = graph.V(node_type).batch(kwargs.get('batch_size', 64)).alias(ego_name)
    query_save = meta_path_sample(seed, node_type, edge_type, ego_name, kwargs.get('nbrs_num', [10, 5]), kwargs.get('sampler', 'random_without_replacement')).values()
    dataset = tfg.Dataset(query_save, window=kwargs.get('window', 10))
    ego_graph = dataset.get_egograph(ego_name)
    emb = model.forward(ego_graph)
    return dataset.iterator, ego_graph.src.ids, emb

## define hyperparameters
node_type = '...'
edge_type = '...'
nbr_num = '...'

## Define what to be saved before starting the training
save_iter, save_ids, save_emb = node_embedding(graph=lg, model=model, node_type=node_type, edge_type=edge_type, nbrs_num=nbr_num)

## Start the training and saving process
trainer = LocalTrainer(save_checkpoint_steps=5, progress_steps=10)
save_file = './saved_emb.txt'
trainer.save_node_embedding_bigdata(save_iter=save_iter, save_ids=save_ids, save_emb=save_emb, 
                                                                    save_file=save_file, block_max_lines=100000, batch_size=batch_size)
```
Notes:
(1) If batch_size >= block_max_lines, it will use the original save_node_embedding function. The final text file in which you saved the embeddings will have the original name. If batch_size < block_max_lines, it will automatically add an appendix to the original name. For example, if your original text file name is emb.txt, when batch_size < block_max_lines, the final files you obtain will be named as emb_0.txt, emb_1.txt, and so on.
